### PR TITLE
expanding timeout to 5 minutes 

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -160,8 +160,8 @@ def container_test(tag):
     container = client.containers.run(image + ':' + tag,
         detach=True,
         environment=dockerenv)
-    # Watch the logs for no more than 2 minutes
-    t_end = time.time() + 60 * 2
+    # Watch the logs for no more than 5 minutes
+    t_end = time.time() + 60 * 5
     logsfound = False
     while time.time() < t_end:
         try:


### PR DESCRIPTION
Ran into this with the Heimdell build process, it has 9K files to chown on startup and when running 3 containers in parallel it can take longer than 2 minutes. 