### PR TITLE
Upping timeouts on screenshot capture and fixing error

### DIFF
--- a/ci/results.template
+++ b/ci/results.template
@@ -1,4 +1,4 @@
-# ![logo](https://ls-ci.nyc3.digitaloceanspaces.com/ls64x64.png)
+# ![logo](https://www.linuxserver.io/static/logo-transparent-bg.87795b96.png)
 # Test Results {{ image }}:{{ meta_tag }}
 
 ## Cumulative: {{ report_status }}


### PR DESCRIPTION
Chrome options was depreciated for selenium and upping timeouts in an attempt to make screenshotting the qemu emulated container testing grab a viable screenshot. 

It is not working perfectly but it is an improvement from the current state. 