### PR TITLE
ARM soft fail. Upload a json file of the report. 

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -57,7 +57,7 @@ class SetEnvs():
                 else:
                     var = envs.split('=')
                     env_dict[var[0]] = var[1]
-                env_dict["S6_VERBOSITY"] = os.environ.get('CI_S6_VERBOSITY')
+                env_dict["S6_VERBOSITY"] = os.environ.get('S6_VERBOSITY')
             except Exception as error:
                 self.logger.exception(error)
                 raise CIError(f"Failed converting DOCKER_ENV: {envs} to dictionary") from error

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -251,6 +251,7 @@ class CI(SetEnvs):
         self.logger.info('Rendering Report')
         env = Environment( loader = FileSystemLoader(os.path.dirname(os.path.realpath(__file__))) )
         template = env.get_template('template.html')
+        self.report_containers = json.loads(json.dumps(self.report_containers,sort_keys=True))
         with open(f'{os.path.dirname(os.path.realpath(__file__))}/index.html', mode="w", encoding='utf-8') as file_:
             file_.write(template.render(
             report_containers=self.report_containers,

--- a/ci/template.html
+++ b/ci/template.html
@@ -231,7 +231,7 @@
       flex-direction: column;
       margin: 10px;
       min-width: 320px;
-      max-width: 600px;
+      max-width: 50vw;
       padding: 0 0 30px 0;
       flex: 1 1 0;
       border-radius: 10px;
@@ -410,7 +410,6 @@
 
     .report-status-fail {
       color: #f44336;
-      ;
     }
 
     .dotnet-notice {

--- a/ci/template.html
+++ b/ci/template.html
@@ -451,8 +451,8 @@
             <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
           </div>
           {% if screenshot == 'true' %}
-          <a href="{{ container }}.png">
-            <img src="{{ container }}.png" alt="{{ container }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'">
+          <a href="{{ tag }}.png">
+            <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'">
           </a>
           {% else %}
           <div class="tag-image">

--- a/ci/template.html
+++ b/ci/template.html
@@ -445,8 +445,7 @@
       <h1>Test Results <strong>{{ image }}:{{ meta_tag }}</strong></h1>
       <h2>Cumulative: <span class="report-status-{{ report_status.lower() }}">{{ report_status }}</span></h2>
       <main>
-        {% for item in report_containers %}
-          {% for tag in item %}
+        {% for tag in report_containers %}
         <section>
           <div class="section-header">
             <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
@@ -460,20 +459,20 @@
             <span>WEB_SCREENSHOT ENV Disabled</span><i class="fas fa-file-image"></i>
           </div>
           {% endif %}
-          <h3 class="build-version">Build Version: {{ item[tag]["build_version"] }}</h3>
+          <h3 class="build-version">Build Version: {{ report_containers[tag]["build_version"] }}</h3>
           <h3>Container Logs</h3>
           <details>
           <summary>Expand</summary>
-          <div class="summary-container"><pre><code>{{ item[tag]["logs"] }}</code>
+          <div class="summary-container"><pre><code>{{ report_containers[tag]["logs"] }}</code>
           </pre></div>
           </details>
           <h3>Package info</h3>
           <details>
           <summary>Expand</summary>
-          <div class="summary-container"><pre><code>{{ item[tag]["sysinfo"] }}</code>
+          <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>
           </pre></div>
           </details>
-          {% if 'arm32' in tag and item[tag]["dotnet"] == true %}
+          {% if 'arm32' in tag and report_containers[tag]["dotnet"] == true %}
           <div class="dotnet-notice">
             <p class="dotnet-heading">Warning:<span class="dotnet-note">May be a .NET app. Service might not start on ARM32 with QEMU</span></p>
           </div>
@@ -488,22 +487,21 @@
                 </tr>
               </thead>
               <tbody>
-                {% for test in item[tag]["tag_tests"] %}
+                {% for test in report_containers[tag]["test_results"] %}
                 <tr>
                   <td>{{ test }}</td>
-                  {% if item[tag]["tag_tests"][test]['status'] == 'PASS' %}
-                  <td class="result-cell">{{ item[tag]["tag_tests"][test]['status'] }} <i class="fas fa-check-circle"></i></td>
+                  {% if report_containers[tag]["test_results"][test]['status'] == 'PASS' %}
+                  <td class="result-cell">{{ report_containers[tag]["test_results"][test]['status'] }} <i class="fas fa-check-circle"></i></td>
                   {% else %}
-                  <td class="result-cell">{{ item[tag]["tag_tests"][test]['status'] }} <i class="fas fa-exclamation-circle"></i></td>
+                  <td class="result-cell">{{ report_containers[tag]["test_results"][test]['status'] }} <i class="fas fa-exclamation-circle"></i></td>
                   {% endif %}
-                  <td>{{ item[tag]["tag_tests"][test]["message"] }}</td>
+                  <td>{{ report_containers[tag]["test_results"][test]["message"] }}</td>
                 </tr>
                 {% endfor %}
               </tbody>
             </table>
           </div>
         </section>
-          {% endfor %}
         {% endfor %}
       </main>
     </div>

--- a/ci/template.html
+++ b/ci/template.html
@@ -244,7 +244,6 @@
     .section-header {
       border-radius: 10px 10px 0 0;
       overflow-wrap: break-word;
-
     }
 
     .section-header-h2 {
@@ -446,34 +445,35 @@
       <h1>Test Results <strong>{{ image }}:{{ meta_tag }}</strong></h1>
       <h2>Cumulative: <span class="report-status-{{ report_status.lower() }}">{{ report_status }}</span></h2>
       <main>
-        {% for container in report_containers %}
+        {% for item in report_containers %}
+          {% for tag in item %}
         <section>
           <div class="section-header">
-            <h2 class="section-header-h2"> {{ image }}:{{ container["tag"] }} </h2>
+            <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
           </div>
           {% if screenshot == 'true' %}
-          <a href="{{ container['tag'] }}.png">
-            <img src="{{ container['tag'] }}.png" alt="{{ container['tag'] }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'">
+          <a href="{{ container }}.png">
+            <img src="{{ container }}.png" alt="{{ container }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'">
           </a>
           {% else %}
           <div class="tag-image">
             <span>WEB_SCREENSHOT ENV Disabled</span><i class="fas fa-file-image"></i>
           </div>
           {% endif %}
-          <h3 class="build-version">Build Version: {{ container["build_version"] }}</h3>
+          <h3 class="build-version">Build Version: {{ item[tag]["build_version"] }}</h3>
           <h3>Container Logs</h3>
           <details>
           <summary>Expand</summary>
-          <div class="summary-container"><pre><code>{{ container["logs"] }}</code>
+          <div class="summary-container"><pre><code>{{ item[tag]["logs"] }}</code>
           </pre></div>
           </details>
           <h3>Package info</h3>
           <details>
           <summary>Expand</summary>
-          <div class="summary-container"><pre><code>{{ container["sysinfo"] }}</code>
+          <div class="summary-container"><pre><code>{{ item[tag]["sysinfo"] }}</code>
           </pre></div>
           </details>
-          {% if 'arm32' in container["tag"] and container["dotnet"] == true %}
+          {% if 'arm32' in tag and item[tag]["dotnet"] == true %}
           <div class="dotnet-notice">
             <p class="dotnet-heading">Warning:<span class="dotnet-note">May be a .NET app. Service might not start on ARM32 with QEMU</span></p>
           </div>
@@ -488,21 +488,22 @@
                 </tr>
               </thead>
               <tbody>
-                {% for test in container["tag_tests"] %}
+                {% for test in item[tag]["tag_tests"] %}
                 <tr>
-                  <td>{{ test[0] }}</td>
-                  {% if test[1] == 'PASS' %}
-                  <td class="result-cell">{{ test[1] }} <i class="fas fa-check-circle"></i></td>
+                  <td>{{ test }}</td>
+                  {% if item[tag]["tag_tests"][test]['status'] == 'PASS' %}
+                  <td class="result-cell">{{ item[tag]["tag_tests"][test]['status'] }} <i class="fas fa-check-circle"></i></td>
                   {% else %}
-                  <td class="result-cell">{{ test[1] }} <i class="fas fa-exclamation-circle"></i></td>
+                  <td class="result-cell">{{ item[tag]["tag_tests"][test]['status'] }} <i class="fas fa-exclamation-circle"></i></td>
                   {% endif %}
-                  <td>{{ test[2] }}</td>
+                  <td>{{ item[tag]["tag_tests"][test]["message"] }}</td>
                 </tr>
                 {% endfor %}
               </tbody>
             </table>
           </div>
         </section>
+          {% endfor %}
         {% endfor %}
       </main>
     </div>

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -42,17 +42,19 @@ full_custom_readme: |
   -e BASE=<alpine or debian based distro> \
   -e SECRET_KEY=<S3 secret> \
   -e ACCESS_KEY=<S3 key> \
-  -e DOCKER_ENV="<optional, Array of env vars seperated by | IE test=test|test2=test2 or single var>" \
-  -e WEB_AUTH="<optional, format user:passord>" \
-  -e WEB_PATH="<optional, format /yourpath>" \
-  -e S3_REGION=<optional, custom S3 Region> \
-  -e S3_BUCKET=<optional, custom S3 Bucket> \
-  -e WEB_SCREENSHOT=<optional, set to false if not a web app> \
-  -e DELAY_START=<optional, time in seconds to delay before taking screenshot> \
-  -e PORT=<optional, port web application listens on internal docker port> \
-  -e SSL=<optional , use ssl for the screenshot true/false> \
+  -e DOCKER_ENV="<optional, Array of env vars seperated by | IE test=test|test2=test2 or single var. Defaults to ''>" \
+  -e WEB_AUTH="<optional, format user:passord. Defaults to 'user:password'>" \
+  -e WEB_PATH="<optional, format /yourpath>. Defaults to ''." \
+  -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
+  -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
+  -e WEB_SCREENSHOT_DELAY=<optional, time in seconds to delay before taking screenshot. Defaults to '30'>
+  -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
+  -e DELAY_START=<optional, time in seconds to delay before taking screenshot. Defaults to '5'> \
+  -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \
+  -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
+  -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'>
   -t lsiodev/ci:latest \
-  python test_build.py
+  python3 test_build.py
   ```
 
   The following line is only in this repo for loop testing:

--- a/test_build.py
+++ b/test_build.py
@@ -9,6 +9,7 @@ def run_test():
     ci.run(ci.tags)
     ci.report_render()
     ci.badge_render()
+    ci.json_render()
     ci.report_upload()
     if ci.report_status == 'PASS':  # Exit based on test results
         logger.info('Tests PASSED')

--- a/test_build.py
+++ b/test_build.py
@@ -7,6 +7,8 @@ from ci.logger import configure_logging
 def run_test():
     """Run tests on container tags then build and upload reports"""
     ci.run(ci.tags)
+    # Don't set the whole report as failed if any of the ARM tag fails. 
+    ci.report_status = 'FAIL' if [ci.report_containers[tag]['test_success'] == False for tag in ci.report_containers.keys() if tag.startswith("amd64")][0] else 'PASS'
     ci.report_render()
     ci.badge_render()
     ci.json_render()


### PR DESCRIPTION
- Rework the report data the template uses.
- Update the template to use the new format.
- Possible to check if a specific tag failed the test with the new json file.
- Adds logic that only marks the whole test as failed if the amd tag fails.
- Uploads a JSON report file with data from all the tests (https://gilbnlsio.s3.eu-north-1.amazonaws.com/linuxserver/lidarr/latest/report.json)
-  Adds a new env `CI_S6_VERBOSITY` that sets `S6_VERBOSITY` or defaults to `2` if not passed.
- Added logging of container env config. 
```
Container config of tag arm32v7-nightly-1.1.1.2664-ls168: ['DOCKER_MODS=ghcr.io/gilbn/theme.park:lidarr', 'TP_ADDON=lidarr-darker', 'S6_VERBOSITY=2', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'PS1=$(whoami)@$(hostname):$(pwd)\\$ ', 'HOME=/root', 'TERM=xterm', 'S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0', 'XDG_CONFIG_HOME=/config/xdg']
```
- Updated the readme docker run example

ARM fail:
![chrome_oQOqGw3EB0](https://user-images.githubusercontent.com/24592972/191902400-d99952cc-c8de-411c-b762-a5fa075d2710.png)


Amd fail:
![chrome_r3mB2eb4kQ](https://user-images.githubusercontent.com/24592972/191842800-efcccd1d-f2ee-4e27-bde1-bb1cd34039b4.png)
