### PR TITLE
Better syntax

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -335,7 +335,7 @@ class CI(SetEnvs):
         self.s3_client.upload_file(file_path, self.bucket, f'{latest_dir}/{object_name}', ExtraArgs=content_type)
 
     def log_upload(self) -> None:
-        """Upload ci.log to S3
+        """Upload the ci.log to S3
 
         Raises:
             Exception: S3UploadFailedError
@@ -351,7 +351,7 @@ class CI(SetEnvs):
     def take_screenshot(self, container: Container, tag:str) -> None:
         """Take a screenshot and save it to self.outdir
 
-        Spins up an lsiodev/tester container and takes a screenshot using Seleium.
+        Spins up an lsiodev/tester container and takes a screenshot using Selenium.
 
         Args:
             `container` (Container): Container object

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from multiprocessing.pool import ThreadPool
+from threading import current_thread
 import os
 import shutil
 import time
@@ -151,6 +152,10 @@ class CI(SetEnvs):
                 'test_results': self.tag_report_tests[tag]['test'],
                 'test_success': test_success
                 }
+
+        # Name the thread for easier debugging.
+        if "amd" in tag or "arm" in tag:
+            current_thread().name = f"{tag[:5].upper()}Thread"
 
         # Start the container
         self.logger.info('Starting test of: %s', tag)

--- a/ci/template.html
+++ b/ci/template.html
@@ -451,7 +451,7 @@
           </div>
           {% if screenshot == 'true' %}
           <a href="{{ tag }}.png">
-            <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'">
+            <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'; this.parentElement.setAttribute('href','404.jpg')">
           </a>
           {% else %}
           <div class="tag-image">

--- a/test_build.py
+++ b/test_build.py
@@ -7,8 +7,10 @@ from ci.logger import configure_logging
 def run_test():
     """Run tests on container tags then build and upload reports"""
     ci.run(ci.tags)
-    # Don't set the whole report as failed if any of the ARM tag fails. 
-    ci.report_status = 'FAIL' if [ci.report_containers[tag]['test_success'] == False for tag in ci.report_containers.keys() if tag.startswith("amd64")][0] else 'PASS'
+    # Don't set the whole report as failed if any of the ARM tag fails.
+    for tag in ci.report_containers.keys():
+        if tag.startswith("amd64") and ci.report_containers[tag]['test_success'] == True:
+            ci.report_status = 'PASS' # Override the report_status if an ARM tag failed, but the amd64 tag passed.
     ci.report_render()
     ci.badge_render()
     ci.json_render()


### PR DESCRIPTION
- Improves readbilty of arm soft fail logic. More pythonic.
    - This will fix test fail if a tag in `-e TAGS`  doesn't have an arch prefix. (Non multiarch images) https://gilbnlsio.s3.eu-north-1.amazonaws.com/linuxserver/lidarr/1.1.1.2664-ls168/index.html
- Fixes href on image if its 404.
- Adds naming of threads (if multiarch) for easier debugging.
    - https://gilbnlsio.s3.eu-north-1.amazonaws.com/linuxserver/lidarr/threadnames-test/ci.log

