### PR TITLE
Add option for multiple warning texts

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -153,14 +153,14 @@ class CI(SetEnvs):
                 'logs': logblob,
                 'sysinfo': packages,
                 'warnings': {
-                    'dotnet': warning_texts["dotnet"] if bool("icu-libs" in packages) and "arm32" in tag else "",
-                    'uwsgi': warning_texts["uwsgi"] if bool("uwsgi" in packages) and "arm" in tag else ""
+                    'dotnet': warning_texts["dotnet"] if "icu-libs" in packages and "arm32" in tag else "",
+                    'uwsgi': warning_texts["uwsgi"] if "uwsgi" in packages and "arm" in tag else ""
                 },
                 'build_version': build_version,
                 'test_results': self.tag_report_tests[tag]['test'],
-                'test_success': test_success
+                'test_success': test_success,
                 }
-
+            self.report_containers[tag]["has_warnings"] = any(warning[1] for warning in self.report_containers[tag]["warnings"].items())
         # Name the thread for easier debugging.
         if "amd" in tag or "arm" in tag:
             current_thread().name = f"{tag[:5].upper()}Thread"

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -104,12 +104,16 @@ class CI(SetEnvs):
             aws_secret_access_key=self.s3_secret)
 
     def run(self,tags: list) -> None:
-        """Will iterate over all the tags running container_test() on each tag multithreaded.
+        """Will iterate over all the tags running container_test() on each tag, multithreaded.
+
+        Also does a pull of the linuxserver/tester:latest image before running container_test.
 
         Args:
             `tags` (list): All the tags we will test on the image.
 
         """
+        self.logger.info("Pulling ghcr.io/linuxserver/tester:latest")
+        self.client.images.pull(repository="ghcr.io/linuxserver/tester", tag="latest") # Pulls latest tester image. 
         thread_pool = ThreadPool(processes=10)
         thread_pool.map(self.container_test,tags)
         display = Display(size=(1920, 1080)) # Setup an x virtual frame buffer (Xvfb) that Selenium can use during the tests.

--- a/ci/template.html
+++ b/ci/template.html
@@ -392,6 +392,7 @@
     .summary-container {
       min-height: 100px;
       height: 300px;
+      margin-top: 0.5em;
       overflow: auto;
       resize: vertical;
     }

--- a/ci/template.html
+++ b/ci/template.html
@@ -92,7 +92,7 @@
         color: rgba(218, 59, 138);
       }
     }
-    .dotnet-note {
+    .warning-note {
       color: #96a2b4;
   }
 
@@ -102,7 +102,7 @@
         color: #738694;
       }
 
-      .dotnet-note {
+      .warning-note {
         color: #738694;
       }
 
@@ -327,7 +327,7 @@
     /*Mobile*/
       section h3,
       section details,
-      .dotnet-notice,
+      .warning-notice,
       .table-container {
           padding: 0 5px;
       }
@@ -412,20 +412,20 @@
       color: #f44336;
     }
 
-    .dotnet-notice {
+    .warning-notice {
       display: inline-flex;
     }
 
-    .dotnet-note {
+    .warning-note {
       padding-left: .5rem;
       font-weight: normal;
   }
 
-    div.dotnet-notice > p {
+    div.warning-notice > p {
       margin-bottom: 0;
     }
 
-    .dotnet-heading {
+    .warning-heading {
       padding-right:5px;
       padding-bottom:0;
       color: darkorange;
@@ -471,11 +471,14 @@
           <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>
           </pre></div>
           </details>
-          {% if 'arm32' in tag and report_containers[tag]["dotnet"] == true %}
-          <div class="dotnet-notice">
-            <p class="dotnet-heading">Warning:<span class="dotnet-note">May be a .NET app. Service might not start on ARM32 with QEMU</span></p>
-          </div>
-          {% endif %}
+          {% for warning in report_containers[tag]["warnings"] %}
+            {% if report_containers[tag]["warnings"][warning] %}
+              <div class="warning-notice">
+                <p class="warning-heading">Warning:<span class="warning-note">{{ report_containers[tag]["warnings"][warning] }}</span></p>
+              </div>
+            {% endif %}
+          {% endfor %}
+
           <div class="table-container">
             <table class="styled-table">
               <thead>

--- a/ci/template.html
+++ b/ci/template.html
@@ -58,6 +58,10 @@
         color: rgba(218, 59, 138);
       }
 
+      .summary:hover {
+        color: rgb(188, 52, 120);
+      }
+
       .styled-table {
         border: solid 1px rgb(255 255 255 / 10%);
       }
@@ -448,6 +452,10 @@
       margin-block-start: 1em;
       color: darkorange;
       font-weight: bold;
+    }
+
+    .warning-summary:hover {
+      color: #ff8c00db;
     }
   </style>
 

--- a/ci/template.html
+++ b/ci/template.html
@@ -54,6 +54,10 @@
         color: rgba(218, 59, 138);
       }
 
+      .summary {
+        color: rgba(218, 59, 138);
+      }
+
       .styled-table {
         border: solid 1px rgb(255 255 255 / 10%);
       }
@@ -291,6 +295,13 @@
       padding: 0 30px;
     }
 
+    .summary {
+      font-weight: bold;
+      margin-block-start: 1em;
+      margin-inline-start: 0px;
+      margin-inline-end: 0px;
+    }
+
     section img {
       width: calc(100% + 60px);
       height: auto;
@@ -374,6 +385,10 @@
       margin-left: 5px;
     }
 
+    .fa-exclamation-triangle {
+      color: darkorange;
+    }
+
     .summary-container {
       min-height: 100px;
       height: 300px;
@@ -418,6 +433,7 @@
 
     .warning-note {
       padding-left: .5rem;
+      padding-top: 0.5em;
       font-weight: normal;
   }
 
@@ -425,9 +441,10 @@
       margin-bottom: 0;
     }
 
-    .warning-heading {
+    .warning-summary {
       padding-right:5px;
       padding-bottom:0;
+      margin-block-start: 1em;
       color: darkorange;
       font-weight: bold;
     }
@@ -459,26 +476,28 @@
           </div>
           {% endif %}
           <h3 class="build-version">Build Version: {{ report_containers[tag]["build_version"] }}</h3>
-          <h3>Container Logs</h3>
           <details>
-          <summary>Expand</summary>
+          <summary class="summary">Container Logs</summary>
           <div class="summary-container"><pre><code>{{ report_containers[tag]["logs"] }}</code>
           </pre></div>
           </details>
-          <h3>Package info</h3>
           <details>
-          <summary>Expand</summary>
+          <summary class="summary">Package info</summary>
           <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>
           </pre></div>
           </details>
-          {% for warning in report_containers[tag]["warnings"] %}
-            {% if report_containers[tag]["warnings"][warning] %}
-              <div class="warning-notice">
-                <p class="warning-heading">Warning:<span class="warning-note">{{ report_containers[tag]["warnings"][warning] }}</span></p>
-              </div>
-            {% endif %}
-          {% endfor %}
-
+          {% if report_containers[tag]["has_warnings"]%}
+          <details open>
+          <summary class="warning-summary">Warnings</summary>
+            {% for warning in report_containers[tag]["warnings"] %}
+              {% if report_containers[tag]["warnings"][warning] %}
+                <div class="warning-notice">
+                  <code class="warning-note"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> {{ report_containers[tag]["warnings"][warning] }}</code>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </details>
+          {% endif %}
           <div class="table-container">
             <table class="styled-table">
               <thead>


### PR DESCRIPTION
## Adds

- Adds new warning if image has uwsgi in package list.
- Made it easier to add new warning notes. 
    - Add a new key,value to the [warning_texts](https://github.com/linuxserver/docker-ci/blob/5f839474185d40371b9d0becf9431b56280c01c8/ci/ci.py#L147) dict and create a rule if the [`report_containers[tag]["warnings"]["key"]`](https://github.com/linuxserver/docker-ci/blob/5f839474185d40371b9d0becf9431b56280c01c8/ci/ci.py#L155) value should have the `warnings_texts` key value.

## Changes

- Reworked how the html summary sections work. Saves some vertical space on the reports.
- Run docker pull on tester image before starting tests.

https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/lidarr/latest/index.html

https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/papermerge/v2.0.1-ls60/index.html

![image](https://user-images.githubusercontent.com/24592972/197861210-c61d0355-9c84-403c-8555-8d6c5d310989.png)
