### PR TITLE
fix up and optimize build deps and keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,55 +7,53 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="TheLamer"
 
 RUN \
- echo "**** install runtime packages ****" && \
- apt-get update && \
- apt-get install -y --no-install-recommends \
-	gnupg \
-	xvfb \
-	xserver-xephyr \
-	unzip && \
- curl -s \
-        https://download.docker.com/linux/debian/gpg | \
-        apt-key add - && \
- curl -s \
-        https://dl-ssl.google.com/linux/linux_signing_key.pub | \
-        apt-key add - && \
- echo 'deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable' > \
-        /etc/apt/sources.list.d/docker-ce.list && \
- echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > \
-        /etc/apt/sources.list.d/google.list && \
- apt-get update && \
- apt-get install -y --no-install-recommends \
-        docker-ce \
-	google-chrome-stable \
-	python3 \
-	python3-pip \
-	python3-setuptools && \
- echo "**** install chrome driver ****" && \
- CHROME_RELEASE=$(curl -sLk https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
- curl -sk -o \
- /tmp/chrome.zip -L \
-	"https://chromedriver.storage.googleapis.com/${CHROME_RELEASE}/chromedriver_linux64.zip" && \
- cd /tmp && \
- unzip chrome.zip && \
- mv chromedriver /usr/bin/chromedriver && \
- chown root:root /usr/bin/chromedriver && \
- chmod +x /usr/bin/chromedriver && \
- echo "**** Install python deps ****" && \
- pip3 install --no-cache-dir \
-	requests \
-	selenium \
-	docker \
-	boto3 \
-	anybadge \
-	pyvirtualdisplay \
-	jinja2 && \
- echo "**** cleanup ****" && \
- apt-get autoclean && \
- rm -rf \
-	/var/lib/apt/lists/* \
-	/var/tmp/* \
-	/tmp/*
+  echo "**** add 3rd party repos ****" && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+  curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | \
+    gpg --dearmor -o /etc/apt/keyrings/google.gpg && \
+  echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > \
+    /etc/apt/sources.list.d/google-chrome.list && \
+  echo "**** install runtime packages ****" && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    docker-ce \
+    google-chrome-stable \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    unzip \
+    xserver-xephyr \
+    xvfb && \
+  echo "**** install chrome driver ****" && \
+  CHROME_RELEASE=$(curl -sLk https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
+  echo "Retrieving Chrome driver version ${CHROME_RELEASE}" && \
+  curl -sk -o \
+    /tmp/chrome.zip -L \
+    "https://chromedriver.storage.googleapis.com/${CHROME_RELEASE}/chromedriver_linux64.zip" && \
+  cd /tmp && \
+  unzip chrome.zip && \
+  mv chromedriver /usr/bin/chromedriver && \
+  chown root:root /usr/bin/chromedriver && \
+  chmod +x /usr/bin/chromedriver && \
+  echo "**** Install python deps ****" && \
+  pip3 install --no-cache-dir \
+    requests \
+    selenium \
+    docker \
+    boto3 \
+    anybadge \
+    pyvirtualdisplay \
+    jinja2 && \
+  echo "**** cleanup ****" && \
+  apt-get autoclean && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    /tmp/*
 
 # copy local files
 COPY ci /ci


### PR DESCRIPTION
keys were using the deprecated apt-key add, they are now updated
docker repo was bionic (likely forgotten during rebase), now updated
print chrome driver version retrieved in build log so we can check and compare the versions of chrome and chrome driver