### PR TITLE
render logs with ansi2html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN \
     selenium \
     docker \
     boto3 \
+    ansi2html \
     anybadge \
     pyvirtualdisplay \
     jinja2 && \

--- a/ci/template.html
+++ b/ci/template.html
@@ -193,6 +193,17 @@
       display: none;
     }
 
+    a {
+        text-decoration: none;
+    }
+
+    a[target="_blank"]::after {
+        content: " \2197";
+        font-size: 80%;
+        margin-left: 4px;
+        vertical-align: middle;
+    }
+
     #app {
       display: flex;
       flex-direction: column;

--- a/ci/template.html
+++ b/ci/template.html
@@ -485,11 +485,9 @@
           </div>
           {% endif %}
           <h3 class="build-version">Build Version: {{ report_containers[tag]["build_version"] }}</h3>
-          <details>
-          <summary class="summary">Container Logs</summary>
-          <div class="summary-container"><pre><code>{{ report_containers[tag]["logs"] }}</code>
-          </pre></div>
-          </details>
+          <summary class="summary">
+            <a href="{{ tag }}.log.html" target="_blank">View Container Logs</a>
+          </summary>
           <details>
           <summary class="summary">Package info</summary>
           <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ci/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
container logs are passed to ansi2html which outputs them alongside the index, as the file `{tag}.log.html`
this allows the logs to be properly formatted any easily read (with colours!)

the container logs dropdown in the CI results has been replaced with a href to directly view the logs.
<img width="204" alt="Screenshot 2023-01-30 at 6 41 57 pm" src="https://user-images.githubusercontent.com/53986978/215416606-1516654d-c634-4048-a1a0-5ce360462aa2.png">
they look something like this, and are rendered in the browser with pure html:
<img width="1512" alt="Screenshot 2023-01-30 at 6 32 09 pm" src="https://user-images.githubusercontent.com/53986978/215414631-e6ac2f88-286d-464f-ad49-05ae2cff9eb3.png">

I'm not going to pretend to be some insane python programmer, the converter has just been placed where it was easiest to access `logblob`

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
No benefits @nemchik thought it was cool, makes reading the logs easier 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
...

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/pycontribs/ansi2html