### PR TITLE
container_test() refactor + @hydazz ansi2html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv
 __pycache__
 .vscode
+/output

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
+COPY requirements.txt /tmp/requirements.txt
+
 RUN \
   echo "**** add 3rd party repos ****" && \
   mkdir -p /etc/apt/keyrings && \
@@ -40,15 +42,7 @@ RUN \
   chown root:root /usr/bin/chromedriver && \
   chmod +x /usr/bin/chromedriver && \
   echo "**** Install python deps ****" && \
-  pip3 install --no-cache-dir \
-    requests \
-    selenium \
-    docker \
-    boto3 \
-    ansi2html \
-    anybadge \
-    pyvirtualdisplay \
-    jinja2 && \
+  pip3 install --no-cache-dir -r /tmp/requirements.txt && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN \
     selenium \
     docker \
     boto3 \
+    ansi2html \
     anybadge \
     pyvirtualdisplay \
     jinja2 && \

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -139,8 +139,7 @@ class CI(SetEnvs):
         5. Add report information to report.json.
         """
         # Name the thread for easier debugging.
-        if "amd" in tag or "arm" in tag:
-            current_thread().name = f"{tag[:5].upper()}Thread"
+        current_thread().name = f"{self.get_platform(tag).upper()}Thread"
 
         # Start the container
         self.logger.info('Starting test of: %s', tag)
@@ -208,6 +207,25 @@ class CI(SetEnvs):
             }
         self.report_containers[tag]["has_warnings"] = any(warning[1] for warning in self.report_containers[tag]["warnings"].items())
 
+    def get_platform(self, tag: str) -> str:
+        """Check the 5 first characters of the tag and return the platform.
+        
+        If no match is found return amd64.
+        
+        Returns:
+            str: The platform
+        """
+        platform = tag[:5]
+        match platform:
+            case "amd64":
+                return "amd64"
+            case "arm64":
+                return "arm64"
+            case "arm32":
+                return "arm"
+            case _:
+                return "amd64"
+
     def export_package_info(self, container:Container, tag:str) -> str:
         """Dump the package info into a string for the report
 
@@ -256,11 +274,14 @@ class CI(SetEnvs):
         Returns:
             bool: Return the output if successful otherwise "ERROR".
         """
-        syft:Container = self.client.containers.run(image="anchore/syft:latest",command=f"{self.image}:{tag}", detach=True)
+        platform = self.get_platform(tag)
+        syft:Container = self.client.containers.run(image="ghcr.io/anchore/syft:v0.76.1",command=f"{self.image}:{tag} --platform=linux/{platform}", 
+            detach=True, volumes={"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"}})
         self.logger.info('Creating SBOM package list on %s',tag)
 
         t_end = time.time() + int(self.logs_delay)
         self.logger.info("Tailing the syft container logs for %s seconds looking the 'VERSION' message on tag: %s",self.logs_delay,tag)
+        error_message = "Did not find the 'VERSION' keyword in the syft container logs"
         while time.time() < t_end:
             time.sleep(5)
             try:
@@ -272,13 +293,19 @@ class CI(SetEnvs):
                         'message':'-'}.items())))
                     self.logger.info('Create SBOM package list %s: PASS', tag)
                     self.create_html_ansi_file(str(logblob),tag,"sbom")
+                    try:
+                        syft.remove(force=True)
+                    except Exception:
+                        self.logger.exception("Failed to remove the syft container, %s",tag)
                     return logblob
             except (APIError,ContainerError,ImageNotFound) as error:
+                error_message = error
                 self.logger.exception('Creating SBOM package list on %s: FAIL', tag)
-                self.tag_report_tests[tag]['test']['Create SBOM'] = (dict(sorted({
-                    'Create SBOM':'FAIL',
-                    'message':str(error)}.items())))
-                self.report_status = 'FAIL'
+        self.logger.error("Failed to generate SBOM output on tag %s. SBOM output:\n%s",tag, logblob)
+        self.report_status = "FAIL"
+        self.tag_report_tests[tag]['test']['Create SBOM'] = (dict(sorted({
+            "Create SBOM":"FAIL",
+            "message":str(error_message)}.items())))
         try:
             syft.remove(force=True)
         except Exception:

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -455,7 +455,7 @@ class CI(SetEnvs):
         """
         try:
             self.logger.info(f"Creating {tag}.{name}.html")
-            converter = Ansi2HTMLConverter()
+            converter = Ansi2HTMLConverter(title=f"{tag}-{name}")
             html_logs = converter.convert(blob)
             with open(f'{self.outdir}/{tag}.{name}.html', 'w', encoding='utf-8') as file:
                 file.write(html_logs)
@@ -485,7 +485,11 @@ class CI(SetEnvs):
         """
         self.logger.info('Uploading logs')
         try:
-            self.upload_file(f"{self.outdir}/ci.log", 'ci.log', {'ContentType': 'text/plain', 'ACL': 'public-read'}) 
+            self.upload_file(f"{self.outdir}/ci.log", 'ci.log', {'ContentType': 'text/plain', 'ACL': 'public-read'})
+            with open(f"{self.outdir}/ci.log","r", encoding='utf-8') as logs:
+                blob = logs.read()
+                self.create_html_ansi_file(blob,"python","log")
+                self.upload_file(f"{self.outdir}/python.log.html", 'python.log.html', {'ContentType': 'text/html', 'ACL': 'public-read'})
         except (S3UploadFailedError, ClientError):
             self.logger.exception('Failed to upload the CI logs!')
 

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -22,7 +22,7 @@ import anybadge
 from ansi2html import Ansi2HTMLConverter
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException, WebDriverException
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pyvirtualdisplay import Display
 
 
@@ -61,7 +61,7 @@ class SetEnvs():
                     env_dict[var[0]] = var[1]
                 env_dict["S6_VERBOSITY"] = os.environ.get('S6_VERBOSITY')
             except Exception as error:
-                self.logger.exception(error)
+                self.logger.exception("Failed to convert DOCKER_ENV: %s to dictionary!", envs)
                 raise CIError(f"Failed converting DOCKER_ENV: {envs} to dictionary") from error
         return env_dict
 
@@ -76,7 +76,7 @@ class SetEnvs():
             self.meta_tag = os.environ['META_TAG']
             self.tags_env = os.environ['TAGS']
         except KeyError as error:
-            self.logger.exception("Key %s is not set in ENV!", error)
+            self.logger.exception("Key is not set in ENV!")
             raise CIError(f'Key {error} is not set in ENV!') from error
 
 
@@ -137,38 +137,6 @@ class CI(SetEnvs):
         4. Take a screenshot for the report.
         5. Add report information to report.json.
         """
-        def _endtest(self: CI, container:Container, tag:str, build_version:str, packages:str, test_success: bool):
-            """End the test with as much info as we have and append to the report.
-
-            Args:
-                `container` (Container): Container object
-                `tag` (str): The container tag
-                `build_version` (str): The Container build version
-                `packages` (str): Package dump from the container
-                `test_success` (bool): If the testing of the container failed or not
-            """
-            logblob = container.logs().decode('utf-8')
-            converter = Ansi2HTMLConverter()
-            html_logs = converter.convert(logblob)
-            with open(f'{self.outdir}/{tag}.log.html', 'w', encoding='utf-8') as file:
-                file.write(html_logs)
-            container.remove(force='true')
-            warning_texts = {
-                "dotnet": "May be a .NET app. Service might not start on ARM32 with QEMU",
-                "uwsgi": "This image uses uWSGI and might not start on ARM/QEMU"
-            }
-            # Add the info to the report
-            self.report_containers[tag] = {
-                'sysinfo': packages,
-                'warnings': {
-                    'dotnet': warning_texts["dotnet"] if "icu-libs" in packages and "arm32" in tag else "",
-                    'uwsgi': warning_texts["uwsgi"] if "uwsgi" in packages and "arm" in tag else ""
-                },
-                'build_version': build_version,
-                'test_results': self.tag_report_tests[tag]['test'],
-                'test_success': test_success,
-                }
-            self.report_containers[tag]["has_warnings"] = any(warning[1] for warning in self.report_containers[tag]["warnings"].items())
         # Name the thread for easier debugging.
         if "amd" in tag or "arm" in tag:
             current_thread().name = f"{tag[:5].upper()}Thread"
@@ -180,59 +148,71 @@ class CI(SetEnvs):
                                                environment=self.dockerenv)
         container_config = container.attrs["Config"]["Env"]
         self.logger.info("Container config of tag %s: %s",tag,container_config)
-        # Watch the logs for no more than 5 minutes
-        logsfound = False
-        t_end = time.time() + 60 * 5
-        self.logger.info("Checking logs for the 'done' message on tag: %s",tag)
-        while time.time() < t_end:
-            try:
-                logblob = container.logs().decode('utf-8')
-                if '[services.d] done.' in logblob or '[ls.io-init] done.' in logblob:
-                    logsfound = True
-                    break
-                time.sleep(1)
-            except APIError as error:
-                self.logger.exception('Container startup failed for %s', tag)
-                self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
-                    'status':'FAIL',
-                    'message': f'INIT NOT FINISHED: {error}'
-                    }.items())))                               
-                self.report_status = 'FAIL'
-                _endtest(self, container, tag, 'ERROR', 'ERROR', False)
-                return
-        # Grab build version
-        try:
-            self.logger.info("Fetching build version on tag: %s",tag)
-            build_version = container.attrs['Config']['Labels']['build_version']
-            self.tag_report_tests[tag]['test']['Get build version'] = (dict(sorted({
-                'status':'PASS',
-                'message':'-'}.items())))
-            self.logger.info('Get build version %s: PASS', tag)
-        except APIError as error:
-            build_version = 'ERROR'
-            self.tag_report_tests[tag]['test']['Get build version'] = (dict(sorted({
-                'status':'FAIL',
-                'message':error}.items())))
-            self.logger.exception('Get build version %s: FAIL', tag)
-            self.report_status = 'FAIL'
-            _endtest(self, container, tag, build_version, 'ERROR', False)
+
+
+        logsfound = self.watch_container_logs(container, tag) # Watch the logs for no more than 5 minutes
+        if not logsfound:
+            self._endtest(container, tag, "ERROR", "ERROR", False)
             return
-        # Check if the startup marker was found in the logs during the 2 minute spinup
-        if logsfound:
-            self.logger.info('Container startup completed for %s', tag)
-            self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
-                'status':'PASS',
-                'message':'-'}.items())))
-            self.logger.info('Container startup %s: PASS', tag)
-        else:
-            self.logger.error('Container startup failed for %s', tag)
-            self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
-                'status':'FAIL',
-                'message':'INIT NOT FINISHED'}.items())))
-            self.logger.error('Container startup %s: FAIL - INIT NOT FINISHED', tag)
-            self.report_status = 'FAIL'
-            _endtest(self, container, tag, build_version, 'ERROR', False)
+
+        build_version = self.get_build_version(container,tag) # Get the image build version
+        if build_version == "ERROR":
+            self._endtest(container, tag, build_version, "ERROR", False)
             return
+
+        packages = self.export_package_info(container, tag) # Dump package information
+        if packages == "ERROR":
+            self._endtest(container, tag, build_version, packages, False)
+            return
+
+        # Screenshot web interface and check connectivity
+        if self.screenshot == 'true':
+            self.take_screenshot(container, tag)
+        # If all info is present end test
+        self._endtest(container, tag, build_version, packages, True)
+        return
+
+    def _endtest(self: 'CI', container:Container, tag:str, build_version:str, packages:str, test_success: bool) -> None:
+        """End the test with as much info as we have and append to the report.
+
+        Args:
+            `container` (Container): Container object
+            `tag` (str): The container tag
+            `build_version` (str): The Container build version
+            `packages` (str): Package dump from the container
+            `test_success` (bool): If the testing of the container failed or not
+        """
+        logblob = container.logs().decode('utf-8')
+        self.create_html_logs(logblob, tag)
+        container.remove(force='true')
+        warning_texts = {
+            "dotnet": "May be a .NET app. Service might not start on ARM32 with QEMU",
+            "uwsgi": "This image uses uWSGI and might not start on ARM/QEMU"
+        }
+        # Add the info to the report
+        self.report_containers[tag] = {
+            'logs': logblob,
+            'sysinfo': packages,
+            'warnings': {
+                'dotnet': warning_texts["dotnet"] if "icu-libs" in packages and "arm32" in tag else "",
+                'uwsgi': warning_texts["uwsgi"] if "uwsgi" in packages and "arm" in tag else ""
+            },
+            'build_version': build_version,
+            'test_results': self.tag_report_tests[tag]['test'],
+            'test_success': test_success,
+            }
+        self.report_containers[tag]["has_warnings"] = any(warning[1] for warning in self.report_containers[tag]["warnings"].items())
+
+    def export_package_info(self, container:Container, tag:str) -> str:
+        """Dump the package info into a string for the report
+
+        Args:
+            container (Container): The container we are testing
+            tag (str): The tag we are testing
+
+        Returns:
+            str: Return the output of the dump command or 'ERROR'
+        """
         # Dump package information
         dump_commands = {
             'alpine': 'apk info -v',
@@ -245,32 +225,95 @@ class CI(SetEnvs):
             self.logger.info('Dumping package info for %s',tag)
             info = container.exec_run(dump_commands[self.base])
             packages = info[1].decode('utf-8')
+            if info[0] != 0:
+                raise CIError(f"Failed to dump packages. Output: {packages}")
             self.tag_report_tests[tag]['test']['Dump package info'] = (dict(sorted({
                 'status':'PASS',
                 'message':'-'}.items())))
             self.logger.info('Dump package info %s: PASS', tag)
-        except (APIError, IndexError) as error:
+        except (APIError, IndexError,CIError) as error:
             packages = 'ERROR'
-            self.logger.exception(str(error))
+            self.logger.exception('Dumping package info on %s: FAIL', tag)
             self.tag_report_tests[tag]['test']['Dump package info'] = (dict(sorted({
                 'Dump package info':'FAIL',
-                'message':error}.items())))
-            self.logger.error('Dump package info %s: FAIL', tag)
+                'message':str(error)}.items())))
             self.report_status = 'FAIL' 
-            _endtest(self, container, tag, build_version, packages, False)
-            return
-        # Screenshot web interface and check connectivity
-        if self.screenshot == 'true':
-            self.take_screenshot(container, tag)
-        # If all info is present end test
-        _endtest(self, container, tag, build_version, packages, True)
-        return
+        return packages
 
+    def get_build_version(self,container:Container,tag:str) -> str:
+        """Fetch the build version from the container object attributes.
+
+        Args:
+            container (Container): The container we are testing
+            tag (str): The current tag we are testing
+
+        Returns:
+            str: Returns the build version or 'ERROR'
+        """
+        try:
+            self.logger.info("Fetching build version on tag: %s",tag)
+            build_version = container.attrs['Config']['Labels']['build_version']
+            self.tag_report_tests[tag]['test']['Get build version'] = (dict(sorted({
+                'status':'PASS',
+                'message':'-'}.items())))
+            self.logger.info('Get build version on tag "%s": PASS', tag)
+        except (APIError,KeyError) as error:
+            self.logger.exception('Get build version on tag "%s": FAIL', tag)
+            build_version = 'ERROR'
+            if isinstance(error,KeyError):
+                error = f"KeyError: {error}"
+            self.tag_report_tests[tag]['test']['Get build version'] = (dict(sorted({
+                'status':'FAIL',
+                'message':str(error)}.items())))
+            self.report_status = 'FAIL'
+        return build_version
+
+    def watch_container_logs(self, container:Container, tag:str) -> bool:
+        """Tail the container logs for 5 minutes and look for the init done message that tells us the container started up
+        successfully.
+
+        Args:
+            container (Container): The container we are testing
+            tag (str): The tag we are testing
+
+        Returns:
+            bool: Return True if the 'done' message is found, otherwise False.
+        """
+        # Watch the logs for no more than 5 minutes
+        t_end = time.time() + 60 * 5
+        self.logger.info("Checking logs for the 'done' message on tag: %s",tag)
+        while time.time() < t_end:
+            try:
+                logblob = container.logs().decode('utf-8')
+                if '[services.d] done.' in logblob or '[ls.io-init] done.' in logblob:
+                    self.logger.info('Container startup completed for %s', tag)
+                    self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
+                        'status':'PASS',
+                        'message':'-'}.items())))
+                    self.logger.info('Container startup %s: PASS', tag)
+                    return True
+                time.sleep(1)
+            except APIError as error:
+                self.logger.exception('Container startup %s: FAIL - INIT NOT FINISHED', tag)
+                self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
+                    'status':'FAIL',
+                    'message': f'INIT NOT FINISHED: {str(error)}'
+                    }.items())))
+                self.report_status = 'FAIL'
+                return False
+        self.logger.error('Container startup failed for %s', tag)
+        self.tag_report_tests[tag]['test']['Container startup'] = (dict(sorted({
+            'status':'FAIL',
+            'message':'INIT NOT FINISHED'}.items())))
+        self.logger.error('Container startup %s: FAIL - INIT NOT FINISHED', tag)
+        self.report_status = 'FAIL'
+        return False
 
     def report_render(self) -> None:
         """Render the index file for upload"""
         self.logger.info('Rendering Report')
-        env = Environment( loader = FileSystemLoader(os.path.dirname(os.path.realpath(__file__))) )
+        env = Environment(autoescape=select_autoescape(enabled_extensions=('html', 'xml'),default_for_string=True),
+                          loader = FileSystemLoader(os.path.dirname(os.path.realpath(__file__))) )
         template = env.get_template('template.html')
         self.report_containers = json.loads(json.dumps(self.report_containers,sort_keys=True))
         with open(f'{os.path.dirname(os.path.realpath(__file__))}/index.html', mode="w", encoding='utf-8') as file_:
@@ -284,7 +327,6 @@ class CI(SetEnvs):
             screenshot=self.screenshot
             ))
 
-
     def badge_render(self) -> None:
         """Render the badge file for upload"""
         self.logger.info("Creating badge")
@@ -294,8 +336,8 @@ class CI(SetEnvs):
             badge.write_badge(f'{self.outdir}/badge.svg')
             with open(f'{self.outdir}/ci-status.yml', 'w', encoding='utf-8') as file:
                 file.write(f'CI: "{self.report_status}"')
-        except (ValueError,RuntimeError,FileNotFoundError,OSError) as error:
-            self.logger.exception(error)
+        except (ValueError,RuntimeError,FileNotFoundError,OSError):
+            self.logger.exception("Failed to render badge file!")
 
     def json_render(self) -> None:
         """Create a JSON file of the report data."""
@@ -304,8 +346,8 @@ class CI(SetEnvs):
             with open(f'{os.path.dirname(os.path.realpath(__file__))}/report.json', mode="w", encoding='utf-8') as file:
                 json.dump(self.report_containers, file, indent=2, sort_keys=True)
             shutil.copyfile(f'{os.path.dirname(os.path.realpath(__file__))}/report.json', f'{self.outdir}/report.json')
-        except (OSError,FileNotFoundError,TypeError,Exception) as error:
-            self.logger.exception(error)
+        except (OSError,FileNotFoundError,TypeError,Exception):
+            self.logger.exception("Failed to render JSON file!")
 
     def report_upload(self) -> None:
         """Upload report files to S3
@@ -323,7 +365,7 @@ class CI(SetEnvs):
         try:
             self.upload_file(index_file, "index.html", ctype)
         except (S3UploadFailedError, ValueError, ClientError) as error:
-            self.logger.exception('Upload Error: %s',error)
+            self.logger.exception('Upload Error!')
             self.log_upload()
             raise CIError(f'Upload Error: {error}') from error
 
@@ -335,11 +377,25 @@ class CI(SetEnvs):
             try:
                 self.upload_file(f'{self.outdir}/{filename}', filename, ctype)
             except (S3UploadFailedError, ValueError, ClientError) as error:
-                self.logger.exception('Upload Error: %s',error)
+                self.logger.exception('Upload Error!')
                 self.log_upload()
                 raise CIError(f'Upload Error: {error}') from error
         self.logger.info('Report available on https://ci-tests.linuxserver.io/%s/index.html', f'{self.image}/{self.meta_tag}')
 
+    def create_html_logs(self, logblob:str, tag:str) -> None:
+        """Creates an HTML file in the 'self.outdir' directory that we upload to S3
+
+        Args:
+            logblob (str): The logblob of the container
+            tag (str): The tag we are testing
+        """
+        try:
+            converter = Ansi2HTMLConverter()
+            html_logs = converter.convert(logblob)
+            with open(f'{self.outdir}/{tag}.log.html', 'w', encoding='utf-8') as file:
+                file.write(html_logs)
+        except Exception:
+            self.logger.exception("Failed to create an HTML file of the %s container logblob.", tag)
 
     def upload_file(self, file_path:str, object_name:str, content_type:dict) -> None:
         """Upload a file to an S3 bucket
@@ -365,8 +421,8 @@ class CI(SetEnvs):
         self.logger.info('Uploading logs')
         try:
             self.upload_file("/ci.log", 'ci.log', {'ContentType': 'text/plain', 'ACL': 'public-read'}) 
-        except (S3UploadFailedError, ClientError) as error:
-            self.logger.exception('Upload Error: %s',error)
+        except (S3UploadFailedError, ClientError):
+            self.logger.exception('Failed to upload the CI logs!')
 
 
     def take_screenshot(self, container: Container, tag:str) -> None:
@@ -383,10 +439,10 @@ class CI(SetEnvs):
         self.logger.info('Sleeping for %s seconds before reloading container: %s and refreshing container attrs', self.test_container_delay, container.image)
         time.sleep(int(self.test_container_delay))
         container.reload()
-        ip_adr = container.attrs['NetworkSettings']['Networks']['bridge']['IPAddress']
-        endpoint = f'{proto}://{self.webauth}@{ip_adr}:{self.port}{self.webpath}'
-        testercontainer, test_endpoint = self.start_tester(proto,endpoint,tag)
         try:
+            ip_adr = container.attrs['NetworkSettings']['Networks']['bridge']['IPAddress']
+            endpoint = f'{proto}://{self.webauth}@{ip_adr}:{self.port}{self.webpath}'
+            testercontainer, test_endpoint = self.start_tester(proto,endpoint,tag)
             driver = self.setup_driver()
             driver.get(test_endpoint)
             self.logger.info('Sleeping for %s seconds before creating a screenshot on %s', self.screenshot_delay, tag)
@@ -400,20 +456,23 @@ class CI(SetEnvs):
         except (requests.Timeout, requests.ConnectionError, KeyError) as error:
             self.tag_report_tests[tag]['test']['Get screenshot'] = (dict(sorted({
                 'status':'FAIL',
-                'message': f'CONNECTION ERROR: {error}'}.items())))
+                'message': f'CONNECTION ERROR: {str(error)}'}.items())))
             self.logger.exception('Screenshot %s FAIL CONNECTION ERROR', tag)
         except TimeoutException as error:
             self.tag_report_tests[tag]['test']['Get screenshot'] = (dict(sorted({
                 'status':'FAIL',
-                'message':f'TIMEOUT: {error}'}.items())))
+                'message':f'TIMEOUT: {str(error)}'}.items())))
             self.logger.exception('Screenshot %s FAIL TIMEOUT', tag)
         except (WebDriverException, Exception) as error:
             self.tag_report_tests[tag]['test']['Get screenshot'] = (dict(sorted({
                 'status':'FAIL',
-                'message':f'UNKNOWN: {error}'}.items())))
-            self.logger.exception('Screenshot %s FAIL UNKNOWN: %s', tag, error)
+                'message':f'UNKNOWN: {str(error)}'}.items())))
+            self.logger.exception('Screenshot %s FAIL UNKNOWN', tag)
         finally:
-            testercontainer.remove(force='true')
+            try:
+                testercontainer.remove(force='true')
+            except Exception:
+                self.logger.exception("Failed to remove tester container")
 
 
     def start_tester(self, proto:str, endpoint:str, tag:str) -> tuple[Container,str]:

--- a/ci/logger.py
+++ b/ci/logger.py
@@ -59,3 +59,4 @@ def configure_logging(log_level:str):
     logging.info('Python version: %s', platform.python_version())
     if log_level.upper() == "DEBUG":
         logging.getLogger("botocore").setLevel(logging.WARNING) # Mute boto3 logging output
+        logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING) # Mute urllib3.connectionpool logging output

--- a/ci/logger.py
+++ b/ci/logger.py
@@ -6,6 +6,14 @@ from logging.handlers import TimedRotatingFileHandler
 import re
 import platform
 
+image = os.environ.get("IMAGE")
+meta_tag = os.environ.get("META_TAG")
+if image and meta_tag:
+    dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),"output",image,meta_tag)
+    os.makedirs(dir, exist_ok=True)
+    log_dir = os.path.join(dir,'ci.log')
+else:
+    log_dir = os.path.join(os.getcwd(),'ci.log')
 
 logger = logging.getLogger()
 
@@ -49,7 +57,7 @@ def configure_logging(log_level:str):
     logger.addHandler(ch)
 
     # File logging
-    fh = TimedRotatingFileHandler(os.path.join(os.getcwd(),'ci.log'), when="midnight", interval=1, backupCount=7, delay=True, encoding='utf-8')
+    fh = TimedRotatingFileHandler(log_dir, when="midnight", interval=1, backupCount=7, delay=True, encoding='utf-8')
     f = CustomLogFormatter('%(asctime)-15s | %(threadName)-17s | %(name)-10s | %(levelname)-8s | (%(module)s.%(funcName)s|line:%(lineno)d) | %(message)s |', '%d/%m/%Y %H:%M:%S')
     fh.setFormatter(f)
     fh.setLevel(log_level)

--- a/ci/logger.py
+++ b/ci/logger.py
@@ -2,37 +2,37 @@
 
 import os
 import logging
+from logging import Logger
 from logging.handlers import TimedRotatingFileHandler
 from logging import LogRecord
 import re
 import platform
 
-image = os.environ.get("IMAGE")
-meta_tag = os.environ.get("META_TAG")
+image: str | None = os.environ.get("IMAGE")
+meta_tag: str | None = os.environ.get("META_TAG")
 if image and meta_tag:
-    dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),"output",image,meta_tag)
+    dir: str = os.path.join(os.path.dirname(os.path.realpath(__file__)),"output",image,meta_tag)
     os.makedirs(dir, exist_ok=True)
-    log_dir = os.path.join(dir,'ci.log')
+    log_dir: str = os.path.join(dir,'ci.log')
 else:
     log_dir = os.path.join(os.getcwd(),'ci.log')
 
-logger = logging.getLogger()
+logger: Logger = logging.getLogger()
 
 class ColorPercentStyle(logging.PercentStyle):
     """Custom log formatter that add color to specific log levels."""
-    grey = "38"
-    blue = "34"
-    yellow = "33"
-    red = "31"
-    cyan = "36"
+    grey: str = "38"
+    yellow: str = "33"
+    red: str = "31"
+    cyan: str = "36"
 
-    def _get_color_fmt(self, color_code, bold=False):
+    def _get_color_fmt(self, color_code, bold=False) -> str:
         if bold:
             return "\x1b[" + color_code + ";1m" + self._fmt + "\x1b[0m"
         return "\x1b[" + color_code + ";20m" + self._fmt + "\x1b[0m"
 
-    def _get_fmt(self, levelno):
-        colors = {
+    def _get_fmt(self, levelno) -> str:
+        colors: dict[int, str] = {
             logging.DEBUG: self._get_color_fmt(self.grey),
             logging.INFO: self._get_color_fmt(self.cyan),
             logging.WARNING: self._get_color_fmt(self.yellow),
@@ -42,27 +42,27 @@ class ColorPercentStyle(logging.PercentStyle):
 
         return colors.get(levelno, self._get_color_fmt(self.grey))
 
-    def _format(self, record:LogRecord):
+    def _format(self, record:LogRecord) -> str:
         return self._get_fmt(record.levelno) % record.__dict__
 
 class CustomLogFormatter(logging.Formatter):
     """Formatter that removes creds from logs."""
-    ACCESS_KEY = os.environ.get("ACCESS_KEY","super_secret_key")
-    SECRET_KEY = os.environ.get("SECRET_KEY","super_secret_key")
+    ACCESS_KEY: str = os.environ.get("ACCESS_KEY","super_secret_key")
+    SECRET_KEY: str = os.environ.get("SECRET_KEY","super_secret_key")
 
-    def formatException(self, exc_info):
+    def formatException(self, exc_info) -> str:
         """Format an exception so that it prints on a single line."""
-        result = super(CustomLogFormatter, self).formatException(exc_info)
+        result: str = super(CustomLogFormatter, self).formatException(exc_info)
         return repr(result)  # or format into one line however you want to
 
-    def format_credential_key(self, s):
+    def format_credential_key(self, s) -> str:
         return re.sub(self.ACCESS_KEY, '(removed)', s)
 
-    def format_secret_key(self, s):
+    def format_secret_key(self, s) -> str:
         return re.sub(self.SECRET_KEY, '(removed)', s)
 
-    def format(self, record):
-        s = super(CustomLogFormatter, self).format(record)
+    def format(self, record) -> str:
+        s: str = super(CustomLogFormatter, self).format(record)
         if record.exc_text:
             s = s.replace('\n', '') + '|'
         s = self.format_credential_key(s)
@@ -70,10 +70,10 @@ class CustomLogFormatter(logging.Formatter):
 
         return s
 
-    def formatMessage(self, record):
+    def formatMessage(self, record) -> str:
         return ColorPercentStyle(self._fmt).format(record)
 
-def configure_logging(log_level:str):
+def configure_logging(log_level:str) -> None:
     """Setup console and file logging"""
 
     logger.handlers = []

--- a/ci/template.html
+++ b/ci/template.html
@@ -530,9 +530,21 @@
           <summary class="summary">
             <a href="{{ tag }}.log.html" target="_blank">View Container Logs</a>
           </summary>
+          <details>
+            <summary>Expand</summary>
+            <div class="summary-container">
+              <pre><code>{{ report_containers[tag]["logs"] }}</code></pre>
+            </div>
+          </details>
           <summary class="summary">
             <a href="{{ tag }}.sbom.html" target="_blank">View SBOM output</a>
           </summary>
+          <details>
+            <summary>Expand</summary>
+            <div class="summary-container">
+              <pre><code>{{ report_containers[tag]["sysinfo"] }}</code></pre>
+            </div>
+          </details>
           {% if report_containers[tag]["has_warnings"]%}
           <details open>
           <summary class="warning-summary">Warnings</summary>

--- a/ci/template.html
+++ b/ci/template.html
@@ -564,7 +564,9 @@
       </main>
     </div>
     <section class="debug-section">
-      <h3><a href="ci.log">Python logs</a></h3>
+      <summary class="summary">
+        <a href="python.log.html" target="_blank">View Python Logs</a>
+      </summary>
       <details>
         <summary>Expand</summary>
         <pre id="logs"></pre>

--- a/ci/template.html
+++ b/ci/template.html
@@ -155,6 +155,9 @@
         background-color: #f3f3f3;
       }
 
+      .section-header-status .report-status-pass {
+        color: #00c29a;
+      }
       .summary-container {
         background: #e8e8e8;
       }
@@ -236,12 +239,17 @@
       width: 100%;
     }
 
-    th {
-      text-align: left
+    .styled-table th,
+    .styled-table td {
+      word-wrap: break-word;
     }
 
-    .result-cell {
-      display: inline-flex;
+    table {
+      table-layout: fixed;
+    }
+
+    th {
+      text-align: left
     }
 
     section {
@@ -272,6 +280,14 @@
       text-align: center;
       flex-wrap: wrap;
     }
+
+    .section-header-status {
+      font-size: 17px;
+      padding-top: .5rem;
+      margin: 0;
+      text-align: center;
+      flex-wrap: wrap;
+  }
 
     em {
       color: #32a7c1;
@@ -484,11 +500,16 @@
         {% for tag in report_containers %}
         <section>
           <div class="section-header">
+            {% if report_containers[tag]["test_success"] %}
+            <h3 class="section-header-status"><span class="report-status-pass">PASS</span></h3>
+            {% else %}
+            <h3 class="section-header-status"><span class="report-status-fail">FAIL</span></h3>
+            {% endif %}
             <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
           </div>
           {% if screenshot == 'true' %}
           <a href="{{ tag }}.png">
-            <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'; this.parentElement.setAttribute('href','404.jpg')">
+            <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'; this.parentElement.setAttribute('href','#')">
           </a>
           {% else %}
           <div class="tag-image">

--- a/ci/template.html
+++ b/ci/template.html
@@ -99,10 +99,15 @@
       strong {
         color: rgba(218, 59, 138);
       }
+      .warning-note {
+        color: #96a2b4;
+      }
+
+      .log-debug {color:lightgray}
+      .log-info {color:lightskyblue}
+      .log-warning {color:darkorange}
+      .log-error {color:red}
     }
-    .warning-note {
-      color: #96a2b4;
-  }
 
     @media (prefers-color-scheme: light) {
       body {
@@ -174,6 +179,11 @@
         border-bottom: 1px solid #dcdcdc;
         background: #f5f5f5;
       }
+
+      .log-debug {color:#9bb0bf}
+      .log-info {color:#60707c}
+      .log-warning {color:darkorange}
+      .log-error {color:red}
     }
 
     body,
@@ -577,8 +587,13 @@
     fetch("ci.log")
       .then(response => response.text())
       .then(logs => {
-        document.getElementById("logs").innerText = logs
-      })
+      pylogs = logs.replace(/\[38;20m/gi,"<span class='log-debug'>"
+        ).replace(/\[33;20m/gi,"<span class='log-warning'>"
+        ).replace(/\[31;20m/gi,"<span class='log-error'>"
+        ).replace(/\[36;20m/gi,"<span class='log-info'>"      
+        ).replace(/\[0m/gi,"</span>")
+        document.getElementById("logs").innerHTML = pylogs
+    })
   </script>
 </body>
 

--- a/ci/template.html
+++ b/ci/template.html
@@ -520,11 +520,9 @@
           <summary class="summary">
             <a href="{{ tag }}.log.html" target="_blank">View Container Logs</a>
           </summary>
-          <details>
-          <summary class="summary">Package info</summary>
-          <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>
-          </pre></div>
-          </details>
+          <summary class="summary">
+            <a href="{{ tag }}.sbom.html" target="_blank">View SBOM output</a>
+          </summary>
           {% if report_containers[tag]["has_warnings"]%}
           <details open>
           <summary class="warning-summary">Warnings</summary>

--- a/ci/template.html
+++ b/ci/template.html
@@ -193,6 +193,17 @@
       display: none;
     }
 
+    a {
+        text-decoration: none;
+    }
+
+    a[target="_blank"]::after {
+        content: " \2197";
+        font-size: 80%;
+        margin-left: 4px;
+        vertical-align: middle;
+    }
+
     #app {
       display: flex;
       flex-direction: column;

--- a/ci/template.html
+++ b/ci/template.html
@@ -485,11 +485,9 @@
           </div>
           {% endif %}
           <h3 class="build-version">Build Version: {{ report_containers[tag]["build_version"] }}</h3>
-          <details>
-          <summary class="summary">Container Logs</summary>
-          <div class="summary-container"><pre><code>{{ report_containers[tag]["logs"] }}</code>
-          </pre></div>
-          </details>
+          <summary class="summary">
+            <a href="{{ tag }}.log.html" target="_blank">View Container Logs</a>
+          </summary>
           <details>
           <summary class="summary">Package info</summary>
           <div class="summary-container"><pre><code>{{ report_containers[tag]["sysinfo"] }}</code>

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,7 @@ full_custom_readme: |
   ```
   sudo docker run --rm -i \
   -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /host/path:/ci/output:rw `#Optional, will contain all the files the container creates.` \
   -e IMAGE="linuxserver/<dockerimage>" \
   -e TAGS="<single tag or array seperated by |>" \
   -e META_TAG=<manifest main dockerhub tag> \
@@ -53,6 +54,7 @@ full_custom_readme: |
   -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \
   -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
   -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'>
+  -e DOCKER_LOGS_DELAY=<optional, How long to wait in seconds while tailing the container logs. Defaults to '300'>
   -t lsiodev/ci:latest \
   python3 test_build.py
   ```

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -53,8 +53,9 @@ full_custom_readme: |
   -e DELAY_START=<optional, time in seconds to delay before taking screenshot. Defaults to '5'> \
   -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \
   -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
-  -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'>
-  -e DOCKER_LOGS_DELAY=<optional, How long to wait in seconds while tailing the container logs. Defaults to '300'>
+  -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'> \
+  -e DOCKER_LOGS_DELAY=<optional, How long to wait in seconds while tailing the container logs. Defaults to '300'> \
+  -e DRY_RUN=<optional, Set to 'true' when you don't want to upload files to S3 when testing>
   -t lsiodev/ci:latest \
   python3 test_build.py
   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ selenium
 jinja2
 requests
 pyvirtualdisplay
+ansi2html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-boto3
-docker
-anybadge
-selenium
-jinja2
-requests
-pyvirtualdisplay
-ansi2html
+boto3==1.26.108
+docker==6.0.1
+anybadge==1.14.0
+selenium==4.8.3
+jinja2==3.1.2
+requests==2.28.2
+pyvirtualdisplay==3.0
+ansi2html==1.8.0

--- a/test_build.py
+++ b/test_build.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import os
-
+from logging import Logger
 from ci.ci import CI, CIError
 from ci.logger import configure_logging
 
-def run_test():
+def run_test() -> None:
     """Run tests on container tags then build and upload reports"""
     ci.run(ci.tags)
     # Don't set the whole report as failed if any of the ARM tag fails.
@@ -26,10 +26,10 @@ def run_test():
 
 if __name__ == '__main__':
     try:
-        log_level = os.environ.get("CI_LOG_LEVEL","INFO")
+        log_level: str = os.environ.get("CI_LOG_LEVEL","INFO")
         configure_logging(log_level)
         import logging
-        logger = logging.getLogger(__name__)
+        logger: Logger = logging.getLogger(__name__)
         ci = CI()
         run_test()
     except Exception as err:


### PR DESCRIPTION
## Fixes

- Made some of the test methods more failure proof.
- Made sure jinja autoescape is enabled when rendering the HTML template.

## Adds

- Adds ansi2html from the @hydazz [pr](https://github.com/linuxserver/docker-ci/pull/27) but with some changes.
- Add new option env: DOCKER_LOGS_DELAY - optional, How long to wait in seconds while tailing the container logs. Defaults to '300'
- Replace the old package dump with [SBOM output](https://github.com/linuxserver/docker-ci/blob/5655549de81bda5382aa3f352bec1021287eac01/ci/ci.py#L280-L327).
- Adds a [get_platform](https://github.com/linuxserver/docker-ci/blob/5655549de81bda5382aa3f352bec1021287eac01/ci/ci.py#L224-L241) method
- Adds a [@testing decorator](https://github.com/linuxserver/docker-ci/blob/5655549de81bda5382aa3f352bec1021287eac01/ci/ci.py#L33-L45) that skips execution of a method if `-e DRY_RUN=true` is set.
  - Used on upload_file() and create_s3_client() methods. 
- Adds [color styling](https://github.com/linuxserver/docker-ci/blob/5655549de81bda5382aa3f352bec1021287eac01/ci/logger.py#L21-L46) to python logs
  - <img width="500" alt="image" src="https://user-images.githubusercontent.com/24592972/231851725-b8f44fc8-1222-40e8-a2c0-0fce81363418.png">
- Adds a [@deprecated decorator](https://github.com/GilbN/docker-ci/blob/container_test-refactor%2Bansi2html/ci/ci.py#L48-L60) 


## Changes

- Splits up container_test() into multiple methods for readabilty.
- Correct exception logging.
- Readded the logblob object to the report_containers dictionary. (For the report.json file)
- Move all created files to be in /ci/output
- Use Ansi2HTMLConverter on the python logs
- Lock requirements.txt versions and use it in the Dockerfile
- Move creation of s3 client to a [function](https://github.com/linuxserver/docker-ci/blob/5655549de81bda5382aa3f352bec1021287eac01/ci/ci.py#L615-L626)
- Stops using the tester image for screenshots. Uses the chromedriver directly instead.

Logger:
- Muted urllib3 when DEBUG is true

Template:
- Fixed table styling
- Added a Pass/Fail header for each tag section
- Disabled anchor href when using the 404 image
- Update template for the new sbom output.

# Test:
https://gilbnlsio2.s3.us-east-1.amazonaws.com/dockersabnzbd/PR29-test5/index.html
https://gilbnlsio2.s3.us-east-1.amazonaws.com/dockersabnzbd/PR29-test4/index.html
https://gilbnlsio2.s3.us-east-1.amazonaws.com/dockersabnzbd/PR29-test12/index.html
