### PR TITLE
Add timeout on take_screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sudo docker run --rm -i \
 -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
 -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
 -e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
--e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
+-e WEB_SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
 -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
 -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
 -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo docker run --rm -i \
 -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
 -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'> \
 -e CI_LOG_LEVEL=<optional, Sets the ci logging level. Defaults to 'INFO'> \
--e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '900'> \
+-e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '120'> \
 -e DRY_RUN=<optional, Set to 'true' when you don't want to upload files to S3 when testing>
 -t lsiodev/ci:latest \
 python3 test_build.py

--- a/README.md
+++ b/README.md
@@ -34,23 +34,24 @@ sudo docker run --rm -i \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /host/path:/ci/output:rw `#Optional, will contain all the files the container creates.` \
 -e IMAGE="linuxserver/<dockerimage>" \
--e TAGS="<single tag or array seperated by |>" \
+-e TAGS="<single tag or array separated by |>" \
 -e META_TAG=<manifest main dockerhub tag> \
 -e BASE=<alpine or debian based distro> \
 -e SECRET_KEY=<S3 secret> \
 -e ACCESS_KEY=<S3 key> \
--e DOCKER_ENV="<optional, Array of env vars seperated by | IE test=test|test2=test2 or single var. Defaults to ''>" \
+-e DOCKER_ENV="<optional, Array of env vars separated by | IE test=test|test2=test2 or single var. Defaults to ''>" \
 -e WEB_AUTH="<optional, format user:passord. Defaults to 'user:password'>" \
 -e WEB_PATH="<optional, format /yourpath>. Defaults to ''." \
 -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
 -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
--e WEB_SCREENSHOT_DELAY=<optional, time in seconds to delay before taking screenshot. Defaults to '30'>
+-e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '60'>
+-e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
 -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
--e DELAY_START=<optional, time in seconds to delay before taking screenshot. Defaults to '5'> \
 -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \
 -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
 -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'> \
--e DOCKER_LOGS_DELAY=<optional, How long to wait in seconds while tailing the container logs. Defaults to '300'> \
+-e CI_LOG_LEVEL=<optional, Sets the ci logging level. Defaults to 'INFO'> \
+-e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '900'> \
 -e DRY_RUN=<optional, Set to 'true' when you don't want to upload files to S3 when testing>
 -t lsiodev/ci:latest \
 python3 test_build.py

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sudo docker run --rm -i \
 -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
 -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
 -e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
--e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '5'> \
+-e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
 -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
 -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
 -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ sudo docker run --rm -i \
 -e WEB_PATH="<optional, format /yourpath>. Defaults to ''." \
 -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
 -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
--e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '60'>
+-e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
+-e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '5'> \
 -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
 -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
 -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -75,7 +75,7 @@ class SetEnvs():
         self.webpath: str = os.environ.get("WEB_PATH", "")
         self.screenshot: bool = os.environ.get("WEB_SCREENSHOT", "false").lower() == "true"
         self.screenshot_timeout: int = os.environ.get("WEB_SCREENSHOT_TIMEOUT", os.environ.get("WEB_SCREENSHOT_DELAY", "120"))
-        self.screenshot_delay: int = os.environ.get("SCREENSHOT_DELAY", "5")
+        self.screenshot_delay: int = os.environ.get("SCREENSHOT_DELAY", "10")
         self.logs_timeout: int = os.environ.get("DOCKER_LOGS_TIMEOUT", os.environ.get("DOCKER_LOGS_DELAY","900"))
         self.sbom_timeout: int = os.environ.get("SBOM_TIMEOUT", "900")
         self.port: int = os.environ.get("PORT", "80")

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -92,7 +92,7 @@ class SetEnvs():
         if os.environ.get("DOCKER_VOLUMES"):
             self.logger.warning("DOCKER_VOLUMES env is not in use")
         if os.environ.get("DOCKER_PRIVILEGED"):
-           self.logger.warning("DOCKER_PRIVILEGED env is not in use")
+            self.logger.warning("DOCKER_PRIVILEGED env is not in use")
 
         self.check_env()
         self.validate_attrs()

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -75,7 +75,7 @@ class SetEnvs():
         self.webpath: str = os.environ.get("WEB_PATH", "")
         self.screenshot: bool = os.environ.get("WEB_SCREENSHOT", "false").lower() == "true"
         self.screenshot_timeout: int = os.environ.get("WEB_SCREENSHOT_TIMEOUT", "120")
-        self.screenshot_delay: int = os.environ.get("SCREENSHOT_DELAY", "10")
+        self.screenshot_delay: int = os.environ.get("WEB_SCREENSHOT_DELAY", "10")
         self.logs_timeout: int = os.environ.get("DOCKER_LOGS_TIMEOUT", "120")
         self.sbom_timeout: int = os.environ.get("SBOM_TIMEOUT", "900")
         self.port: int = os.environ.get("PORT", "80")
@@ -109,7 +109,7 @@ class SetEnvs():
         WEB_PATH:               '{os.environ.get("WEB_PATH")}'
         WEB_SCREENSHOT:         '{os.environ.get("WEB_SCREENSHOT")}'
         WEB_SCREENSHOT_TIMEOUT: '{os.environ.get("WEB_SCREENSHOT_TIMEOUT")}'
-        SCREENSHOT_DELAY:       '{os.environ.get("SCREENSHOT_DELAY")}'
+        WEB_SCREENSHOT_DELAY:   '{os.environ.get("WEB_SCREENSHOT_DELAY")}'
         DOCKER_LOGS_TIMEOUT:    '{os.environ.get("DOCKER_LOGS_TIMEOUT")}'
         SBOM_TIMEOUT:           '{os.environ.get("SBOM_TIMEOUT")}'
         DELAY_START:            '{os.environ.get("DELAY_START")}' (Not in use)

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -8,14 +8,15 @@ import time
 import logging
 from logging import Logger
 import mimetypes
-import requests
 import json
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from functools import wraps
 from typing import Callable, Any, Literal
+from textwrap import dedent
 
 import boto3
+import requests
 from boto3.exceptions import S3UploadFailedError
 from botocore.exceptions import ClientError
 import docker
@@ -33,7 +34,8 @@ from pyvirtualdisplay import Display
 logger: Logger = logging.getLogger(__name__)
 
 def testing(func: Callable):
-    """If the DRY_RUN env is set and this decorator is used on a function it will return None                   
+    """If the DRY_RUN env is set and this decorator is used on a function it will return None
+
     Args:
         func (function): A function
     """
@@ -67,18 +69,71 @@ class SetEnvs():
         os.environ["S6_VERBOSITY"] = os.environ.get("CI_S6_VERBOSITY","2")
         # Set the optional parameters
         self.dockerenv: dict[str, str] = self.convert_env(os.environ.get("DOCKER_ENV", ""))
+        self.docker_volumes: list[str] = self.convert_volumes(os.environ.get("DOCKER_VOLUMES", ""))
+        self.docker_privileged: bool = os.environ.get("DOCKER_PRIVILEGED", "false").lower() == "true"
         self.webauth: str = os.environ.get("WEB_AUTH", "user:password")
         self.webpath: str = os.environ.get("WEB_PATH", "")
-        self.screenshot: str = os.environ.get("WEB_SCREENSHOT", "false")
-        self.screenshot_delay: str = os.environ.get("WEB_SCREENSHOT_DELAY", "30")
-        self.logs_delay: str = os.environ.get("DOCKER_LOGS_DELAY", "900")
+        self.screenshot: bool = os.environ.get("WEB_SCREENSHOT", "false").lower() == "true"
+        self.screenshot_timeout: str = os.environ.get("WEB_SCREENSHOT_TIMEOUT", os.environ.get("WEB_SCREENSHOT_DELAY", "30"))
+        self.logs_timeout: str = os.environ.get("DOCKER_LOGS_TIMEOUT", os.environ.get("DOCKER_LOGS_DELAY","900"))
+        self.sbom_timeout: str = os.environ.get("SBOM_TIMEOUT", "900")
         self.port: str = os.environ.get("PORT", "80")
         self.ssl: str = os.environ.get("SSL", "false")
         self.region: str = os.environ.get("S3_REGION", "us-east-1")
         self.bucket: str = os.environ.get("S3_BUCKET", "ci-tests.linuxserver.io")
-        self.test_container_delay: str = os.environ.get("DELAY_START", "5")
-        self.check_env()
+        
+        if os.environ.get("WEB_SCREENSHOT_DELAY"):
+            self.logger.warning("WEB_SCREENSHOT_DELAY env is deprecated, please use WEB_SCREENSHOT_TIMEOUT instead")
+        if os.environ.get("DOCKER_LOGS_DELAY"):
+            self.logger.warning("DOCKER_LOGS_DELAY env is deprecated, please use DOCKER_LOGS_TIMEOUT instead")
+        if os.environ.get("DELAY_START"):
+            self.logger.warning("DELAY_START env is obsolete, and not in use anymore")
+        if os.environ.get("DOCKER_VOLUMES"):
+            self.logger.warning("DOCKER_VOLUMES env is not in use")
+        if os.environ.get("DOCKER_PRIVILEGED"):
+           self.logger.warning("DOCKER_PRIVILEGED env is not in use")
 
+        self.check_env()
+        
+        env_data = dedent(f"""
+        ENVIRONMENT DATA:
+        IMAGE:                  '{os.environ.get("IMAGE")}'
+        BASE:                   '{os.environ.get("BASE")}'
+        META_TAG:               '{os.environ.get("META_TAG")}'
+        TAGS:                   '{os.environ.get("TAGS")}'
+        S6_VERBOSITY:           '{os.environ.get("S6_VERBOSITY")}'
+        DOCKER_ENV:             '{os.environ.get("DOCKER_ENV")}'
+        DOCKER_VOLUMES:         '{os.environ.get("DOCKER_VOLUMES")}' (Not in use)
+        DOCKER_PRIVILEGED:      '{os.environ.get("DOCKER_PRIVILEGED")}' (Not in use)
+        WEB_AUTH:               '{os.environ.get("WEB_AUTH")}'
+        WEB_PATH:               '{os.environ.get("WEB_PATH")}'
+        WEB_SCREENSHOT:         '{os.environ.get("WEB_SCREENSHOT")}'
+        WEB_SCREENSHOT_TIMEOUT: '{os.environ.get("WEB_SCREENSHOT_TIMEOUT")}'
+        WEB_SCREENSHOT_DELAY:   '{os.environ.get("WEB_SCREENSHOT_DELAY")}' (Deprecated)
+        DOCKER_LOGS_TIMEOUT:    '{os.environ.get("DOCKER_LOGS_TIMEOUT")}'
+        DOCKER_LOGS_DELAY:      '{os.environ.get("DOCKER_LOGS_DELAY")}' (Deprecated)
+        SBOM_TIMEOUT:           '{os.environ.get("SBOM_TIMEOUT")}'
+        DELAY_START:            '{os.environ.get("DELAY_START")}' (Not in use)
+        PORT:                   '{os.environ.get("PORT")}'
+        SSL:                    '{os.environ.get("SSL")}'
+        S3_REGION:              '{os.environ.get("S3_REGION")}'
+        S3_BUCKET:              '{os.environ.get("S3_BUCKET")}'
+        """)
+        logger.info(env_data)
+
+    def _split_key_value_string(self, kv:str, make_list:bool = False) -> dict[str,str] | list[str]:
+        """Split a key value string into a dictionary or list.
+
+        Args:
+            kv (str): A string with key values separated by the pipe symbol. e.g `key1=val1|key2=val2`.
+            make_list (bool, optional): If the value should be a list of strings where the key and value is separated by :. Defaults to False.
+
+        Returns:
+            dict[str,str]: Returns a dictionary with our keys and values.
+        """
+        if make_list:
+            return [f"{k}:{v}" for k,v in (item.split("=") for item in kv.split("|"))]
+        return {k: v for k, v in (item.split("=") for item in kv.split("|"))}
 
     def convert_env(self, envs:str = None) -> dict[str,str]:
         """Convert env DOCKER_ENV to dictionary
@@ -96,19 +151,34 @@ class SetEnvs():
         if envs:
             self.logger.info("Converting envs")
             try:
-                if "|" in envs:
-                    for varpair in envs.split("|"):
-                        var: list[str] = varpair.split("=")
-                        env_dict[var[0]] = var[1]
-                else:
-                    var = envs.split("=")
-                    env_dict[var[0]] = var[1]
+                env_dict = self._split_key_value_string(envs)
                 env_dict["S6_VERBOSITY"] = os.environ.get("S6_VERBOSITY")
             except Exception as error:
                 self.logger.exception("Failed to convert DOCKER_ENV: %s to dictionary!", envs)
                 raise CIError(f"Failed converting DOCKER_ENV: {envs} to dictionary") from error
         return env_dict
 
+    def convert_volumes(self, volumes:str = None) -> list[str]:
+        """Convert env DOCKER_VOLUMES to list
+
+        Args:
+            volumes (str, optional): A string with key values separated by the pipe symbol. e.g `key1=val1|key2=val2`. Defaults to None.
+
+        Raises:
+            CIError: Raises a CIError Exception if it failes to parse the string
+
+        Returns:
+            list[str]: Returns a list with our keys and values.
+        """
+        volume_list: list = []
+        if volumes:
+            self.logger.info("Converting volumes")
+            try:
+                volume_list = self._split_key_value_string(volumes, make_list=True)
+            except Exception as error:
+                self.logger.exception("Failed to convert DOCKER_VOLUME: %s to list!", volumes)
+                raise CIError(f"Failed converting DOCKER_VOLUME: {volumes} to list") from error
+        return volume_list
 
     def check_env(self) -> None:
         """Make sure all needed ENVs are set
@@ -130,6 +200,15 @@ class SetEnvs():
 
 class CI(SetEnvs):
     """CI object to use for testing image tags.
+
+    Attributes:
+        client (DockerClient): Docker client object
+        tags (list): List of tags to test
+        tag_report_tests (dict): Dictionary to hold the test results for each tag
+        report_containers (dict): Dictionary to hold the report information for each tag
+        report_status (str): The status of the report
+        outdir (str): The output directory
+        s3_client (boto3.client): S3 client object
 
     Args:
         SetEnvs (Object): Helper class that initializes and checks that all the necessary enviroment variables exists. Object is initialized upon init of CI.
@@ -172,10 +251,11 @@ class CI(SetEnvs):
         1. Spins up the container tag
             Checks the container logs for either `[services.d] done.` or `[ls.io-init] done.`
         2. Export the build version from the Container object.
-        3. Export the package info from the Container object.
-        4. Take a screenshot for the report.
+        3. Export the package info (SBOM) from the Container object.
+        4. Take a screenshot for the report if the screenshot env is true.
         5. Add report information to report.json.
         """
+        start_time = time.time()
         # Name the thread for easier debugging.
         current_thread().name = f"{self.get_platform(tag).upper()}Thread"
 
@@ -190,29 +270,31 @@ class CI(SetEnvs):
 
         logsfound: bool = self.watch_container_logs(container, tag) # Watch the logs for no more than 5 minutes
         if not logsfound:
+            self.logger.error("Test of %s FAILED after %.2f seconds", tag, time.time() - start_time)
             self._endtest(container, tag, "ERROR", "ERROR", False)
             return
 
         # build_version: str = self.get_build_version(container,tag) # Get the image build version
         build_info: dict = self.get_build_info(container,tag) # Get the image build info
         if build_info["version"] == "ERROR":
+            self.logger.error("Test of %s FAILED after %.2f seconds", tag, time.time() - start_time)
             self._endtest(container, tag, build_info, "ERROR", False)
             return
 
         sbom: str = self.generate_sbom(tag)
         if sbom == "ERROR":
+            self.logger.error("Test of %s FAILED after %.2f seconds", tag, time.time() - start_time)
             self._endtest(container, tag, build_info, sbom, False)
             return
 
         # Screenshot web interface and check connectivity
-        if self.screenshot == "true":
-            self.take_screenshot(container, tag)
+        self.take_screenshot(container, tag)
 
         self._endtest(container, tag, build_info, sbom, True)
-        self.logger.info("Testing of %s PASSED", tag)
+        self.logger.info("Test of %s PASSED after %.2f seconds", tag, time.time() - start_time)
         return
 
-    def _endtest(self: "CI", container:Container, tag:str, build_info:dict[str,str], packages:str, test_success: bool) -> None:
+    def _endtest(self, container:Container, tag:str, build_info:dict[str,str], packages:str, test_success: bool) -> None:
         """End the test with as much info as we have and append to the report.
 
         Args:
@@ -319,9 +401,9 @@ class CI(SetEnvs):
         syft:Container = self.client.containers.run(image="ghcr.io/anchore/syft:latest",command=f"{self.image}:{tag} --platform=linux/{platform}", 
             detach=True, volumes={"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"}})
         self.logger.info("Creating SBOM package list on %s",tag)
-
-        t_end: float = time.time() + int(self.logs_delay)
-        self.logger.info("Tailing the syft container logs for %s seconds looking the 'VERSION' message on tag: %s",self.logs_delay,tag)
+        test = "Create SBOM"
+        t_end: float = time.time() + int(self.sbom_timeout)
+        self.logger.info("Tailing the syft container logs for %s seconds looking the 'VERSION' message on tag: %s",self.sbom_timeout,tag)
         error_message = "Did not find the 'VERSION' keyword in the syft container logs"
         while time.time() < t_end:
             time.sleep(5)
@@ -329,10 +411,8 @@ class CI(SetEnvs):
                 logblob: str = syft.logs().decode("utf-8")
                 if "VERSION" in logblob:
                     self.logger.info("Get package versions for %s completed", tag)
-                    self.tag_report_tests[tag]["test"]["Create SBOM"] = (dict(sorted({
-                        "status":"PASS",
-                        "message":"-"}.items())))
-                    self.logger.info("Create SBOM package list %s: PASS", tag)
+                    self._add_test_result(tag, test, "PASS", "-")
+                    self.logger.info("%s package list %s: PASS", test, tag)
                     self.create_html_ansi_file(str(logblob),tag,"sbom")
                     try:
                         syft.remove(force=True)
@@ -344,9 +424,7 @@ class CI(SetEnvs):
                 self.logger.exception("Creating SBOM package list on %s: FAIL", tag)
         self.logger.error("Failed to generate SBOM output on tag %s. SBOM output:\n%s",tag, logblob)
         self.report_status = "FAIL"
-        self.tag_report_tests[tag]["test"]["Create SBOM"] = (dict(sorted({
-            "Create SBOM":"FAIL",
-            "message":str(error_message)}.items())))
+        self._add_test_result(tag, test, "FAIL", str(error_message))
         try:
             syft.remove(force=True)
         except Exception:
@@ -401,7 +479,7 @@ class CI(SetEnvs):
             }
             ```
         """
-        
+        test = "Get build info"
         try:
             self.logger.info("Fetching build info on tag: %s",tag)
             build_info: dict[str,str] = {
@@ -410,23 +488,19 @@ class CI(SetEnvs):
                 "size": "%.2f" % float(int(container.image.attrs["Size"])/1000000) + "MB",
                 "maintainer": container.attrs["Config"]["Labels"]["maintainer"],
             }
-            self.tag_report_tests[tag]["test"]["Get build info"] = (dict(sorted({
-                "status":"PASS",
-                "message":"-"}.items())))
+            self._add_test_result(tag, test, "PASS", "-")
             self.logger.info("Get build info on tag '%s': PASS", tag)
         except (APIError,KeyError) as error:
             self.logger.exception("Get build info on tag '%s': FAIL", tag)
             build_info = {"version": "ERROR", "created": "ERROR", "size": "ERROR", "maintainer": "ERROR"}
             if isinstance(error,KeyError):
                 error: str = f"KeyError: {error}"
-            self.tag_report_tests[tag]["test"]["Get build info"] = (dict(sorted({
-                "status":"FAIL",
-                "message":str(error)}.items())))
+            self._add_test_result(tag, test, "FAIL", str(error))
             self.report_status = "FAIL"
         return build_info
 
     def watch_container_logs(self, container:Container, tag:str) -> bool:
-        """Tail the container logs for 5 minutes and look for the init done message that tells us the container started up
+        """Tail the container logs for n seconds and look for the init done message that tells us the container started up
         successfully.
 
         Args:
@@ -436,32 +510,26 @@ class CI(SetEnvs):
         Returns:
             bool: Return True if the "done" message is found, otherwise False.
         """
-        t_end: float = time.time() + int(self.logs_delay)
-        self.logger.info("Tailing the %s logs for %s seconds looking for the 'done' message", tag, self.logs_delay)
+        test = "Container startup"
+        t_end: float = time.time() + int(self.logs_timeout)
+        self.logger.info("Tailing the %s logs for %s seconds looking for the 'done' message", tag, self.logs_timeout)
         while time.time() < t_end:
             try:
                 logblob: str = container.logs().decode("utf-8")
                 if "[services.d] done." in logblob or "[ls.io-init] done." in logblob:
-                    self.logger.info("Container startup completed for %s", tag)
-                    self.tag_report_tests[tag]["test"]["Container startup"] = (dict(sorted({
-                        "status":"PASS",
-                        "message":"-"}.items())))
-                    self.logger.info("Container startup %s: PASS", tag)
+                    self.logger.info("%s completed for %s",test, tag)
+                    self._add_test_result(tag, test, "PASS", "-")
+                    self.logger.info("%s %s: PASS", test, tag)
                     return True
                 time.sleep(1)
             except APIError as error:
-                self.logger.exception("Container startup %s: FAIL - INIT NOT FINISHED", tag)
-                self.tag_report_tests[tag]["test"]["Container startup"] = (dict(sorted({
-                    "status":"FAIL",
-                    "message": f"INIT NOT FINISHED: {str(error)}"
-                    }.items())))
+                self.logger.exception("%s %s: FAIL - INIT NOT FINISHED", test, tag)
+                self._add_test_result(tag, test, "FAIL", f"INIT NOT FINISHED: {str(error)}")
                 self.report_status = "FAIL"
                 return False
-        self.logger.error("Container startup failed for %s", tag)
-        self.tag_report_tests[tag]["test"]["Container startup"] = (dict(sorted({
-            "status":"FAIL",
-            "message":"INIT NOT FINISHED"}.items())))
-        self.logger.error("Container startup %s: FAIL - INIT NOT FINISHED", tag)
+        self.logger.error("%s failed for %s", test, tag)
+        self._add_test_result(tag, test, "FAIL", "INIT NOT FINISHED")
+        self.logger.error("%s %s: FAIL - INIT NOT FINISHED", test, tag)
         self.report_status = "FAIL"
         return False
 
@@ -556,9 +624,9 @@ class CI(SetEnvs):
         """Upload a file to an S3 bucket
 
         Args:
-            `file_path` (str): File to upload
-            `bucket` (str): Bucket to upload to
-            `object_name` (str): S3 object name.
+            file_path (str): File to upload
+            object_name (str): S3 object name.
+            content_type (dict): Content type for the file
         """
         self.logger.info("Uploading %s to %s bucket",file_path, self.bucket)
         destination_dir: str = f"{self.image}/{self.meta_tag}"
@@ -583,48 +651,66 @@ class CI(SetEnvs):
         except (S3UploadFailedError, ClientError):
             self.logger.exception("Failed to upload the CI logs!")
 
+    def _add_test_result(self, tag:str, test:str, status:str, message:str) -> None:
+        """Add a test result to the report
+
+        Args:
+            tag (str): The tag we are testing
+            test (str): The test we are running
+            status (str): The status of the test
+            message (str): The message of the test
+        """
+        if status not in ["PASS","FAIL"]:
+            raise ValueError("Status must be either PASS or FAIL")
+        if tag not in self.tags:
+            raise ValueError("Tag not in the list of tags")
+        self.tag_report_tests[tag]["test"][test] = (dict(sorted({
+            "status":status,
+            "message":message}.items())))
 
     def take_screenshot(self, container: Container, tag:str) -> None:
-        """Take a screenshot and save it to self.outdir
-
+        """Take a screenshot and save it to self.outdir if self.screenshot is True
+        
         Takes a screenshot using a ChromiumDriver instance.
 
         Args:
-            `container` (Container): Container object
-            `tag` (str): The container tag we are testing.
+            container (Container): Container object
+            tag (str): The container tag we are testing.
         """
+        if not self.screenshot:
+            return
         proto: Literal["https", "http"] = "https" if self.ssl.upper() == "TRUE" else "http"
-        # Sleep for the user specified amount of time
-        self.logger.info("Sleeping for %s seconds before reloading container: %s and refreshing container attrs", self.test_container_delay, container.image)
-        time.sleep(int(self.test_container_delay))
-        container.reload()
+        screenshot_timeout = time.time() + int(self.screenshot_timeout)
+        test = "Get screenshot"
         try:
-            ip_adr: str = container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"]
-            endpoint: str = f"{proto}://{self.webauth}@{ip_adr}:{self.port}{self.webpath}"
             driver: WebDriver = self.setup_driver()
-            driver.get(endpoint)
-            self.logger.info("Sleeping for %s seconds before creating a screenshot on %s", self.screenshot_delay, tag)
-            time.sleep(int(self.screenshot_delay))
-            self.logger.info("Taking screenshot of %s at %s", tag, endpoint)
-            driver.get_screenshot_as_file(f"{self.outdir}/{tag}.png")
-            self.tag_report_tests[tag]["test"]["Get screenshot"] = (dict(sorted({
-                "status":"PASS",
-                "message":"-"}.items())))
-            self.logger.info("Screenshot %s: PASS", tag)
+            while time.time() < screenshot_timeout:
+                try:
+                    container.reload()
+                    ip_adr:str = container.attrs.get("NetworkSettings",{}).get("Networks",{}).get("bridge",{}).get("IPAddress","")
+                    endpoint: str = f"{proto}://{self.webauth}@{ip_adr}:{self.port}{self.webpath}"
+                    driver.get(endpoint)
+                    self.logger.info("Trying to take screenshot of %s at %s", tag, endpoint)
+                    driver.get_screenshot_as_file(f"{self.outdir}/{tag}.png")
+                    if not os.path.isfile(f"{self.outdir}/{tag}.png"):
+                        continue
+                    self._add_test_result(tag, test, "PASS", "-")
+                    self.logger.info("Screenshot %s: PASS", tag)
+                except Exception as error:
+                    logger.debug("Failed to take screenshot of %s at %s, trying again in 1 second", tag, endpoint)
+                    logger.debug("Error: %s", error)
+                    time.sleep(1)
+                    if time.time() >= screenshot_timeout:
+                        self.logger.error("Failed to take screenshot of %s at %s", tag, endpoint)
+                        raise error
         except (requests.Timeout, requests.ConnectionError, KeyError) as error:
-            self.tag_report_tests[tag]["test"]["Get screenshot"] = (dict(sorted({
-                "status":"FAIL",
-                "message": f"CONNECTION ERROR: {str(error)}"}.items())))
+            self._add_test_result(tag, test, "FAIL", f"CONNECTION ERROR: {str(error)}")
             self.logger.exception("Screenshot %s FAIL CONNECTION ERROR", tag)
         except TimeoutException as error:
-            self.tag_report_tests[tag]["test"]["Get screenshot"] = (dict(sorted({
-                "status":"FAIL",
-                "message":f"TIMEOUT: {str(error)}"}.items())))
+            self._add_test_result(tag, test, "FAIL", f"TIMEOUT: {str(error)}")
             self.logger.exception("Screenshot %s FAIL TIMEOUT", tag)
         except (WebDriverException, Exception) as error:
-            self.tag_report_tests[tag]["test"]["Get screenshot"] = (dict(sorted({
-                "status":"FAIL",
-                "message":f"UNKNOWN: {str(error)}"}.items())))
+            self._add_test_result(tag, test, "FAIL", f"UNKNOWN: {str(error)}")
             self.logger.exception("Screenshot %s FAIL UNKNOWN", tag)
         finally:
             try:

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -74,19 +74,15 @@ class SetEnvs():
         self.webauth: str = os.environ.get("WEB_AUTH", "user:password")
         self.webpath: str = os.environ.get("WEB_PATH", "")
         self.screenshot: bool = os.environ.get("WEB_SCREENSHOT", "false").lower() == "true"
-        self.screenshot_timeout: int = os.environ.get("WEB_SCREENSHOT_TIMEOUT", os.environ.get("WEB_SCREENSHOT_DELAY", "120"))
+        self.screenshot_timeout: int = os.environ.get("WEB_SCREENSHOT_TIMEOUT", "120")
         self.screenshot_delay: int = os.environ.get("SCREENSHOT_DELAY", "10")
-        self.logs_timeout: int = os.environ.get("DOCKER_LOGS_TIMEOUT", os.environ.get("DOCKER_LOGS_DELAY","900"))
+        self.logs_timeout: int = os.environ.get("DOCKER_LOGS_TIMEOUT", "120")
         self.sbom_timeout: int = os.environ.get("SBOM_TIMEOUT", "900")
         self.port: int = os.environ.get("PORT", "80")
         self.ssl: str = os.environ.get("SSL", "false")
         self.region: str = os.environ.get("S3_REGION", "us-east-1")
         self.bucket: str = os.environ.get("S3_BUCKET", "ci-tests.linuxserver.io")
-        
-        if os.environ.get("WEB_SCREENSHOT_DELAY"):
-            self.logger.warning("WEB_SCREENSHOT_DELAY env is deprecated, please use WEB_SCREENSHOT_TIMEOUT instead")
-        if os.environ.get("DOCKER_LOGS_DELAY"):
-            self.logger.warning("DOCKER_LOGS_DELAY env is deprecated, please use DOCKER_LOGS_TIMEOUT instead")
+
         if os.environ.get("DELAY_START"):
             self.logger.warning("DELAY_START env is obsolete, and not in use anymore")
         if os.environ.get("DOCKER_VOLUMES"):
@@ -113,10 +109,8 @@ class SetEnvs():
         WEB_PATH:               '{os.environ.get("WEB_PATH")}'
         WEB_SCREENSHOT:         '{os.environ.get("WEB_SCREENSHOT")}'
         WEB_SCREENSHOT_TIMEOUT: '{os.environ.get("WEB_SCREENSHOT_TIMEOUT")}'
-        WEB_SCREENSHOT_DELAY:   '{os.environ.get("WEB_SCREENSHOT_DELAY")}' (Deprecated)
         SCREENSHOT_DELAY:       '{os.environ.get("SCREENSHOT_DELAY")}'
         DOCKER_LOGS_TIMEOUT:    '{os.environ.get("DOCKER_LOGS_TIMEOUT")}'
-        DOCKER_LOGS_DELAY:      '{os.environ.get("DOCKER_LOGS_DELAY")}' (Deprecated)
         SBOM_TIMEOUT:           '{os.environ.get("SBOM_TIMEOUT")}'
         DELAY_START:            '{os.environ.get("DELAY_START")}' (Not in use)
         PORT:                   '{os.environ.get("PORT")}'

--- a/ci/logger.py
+++ b/ci/logger.py
@@ -19,12 +19,30 @@ else:
 
 logger: Logger = logging.getLogger()
 
+# Add custom log level for success messages
+logging.SUCCESS = 25
+logging.addLevelName(logging.SUCCESS, "SUCCESS")
+
+def success(self:'Logger', message:str, *args, **kwargs):
+    """Log 'message % args' with severity 'SUCCESS'.
+    
+    To pass exception information, use the keyword argument exc_info with
+    a true value, e.g.
+    
+    logger.success("Houston, Tranquility Base Here. The Eagle has Landed.", exc_info=1)
+    """
+    if self.isEnabledFor(logging.SUCCESS):
+        self._log(logging.SUCCESS, message, args, **kwargs)
+
+logging.Logger.success = success
+
 class ColorPercentStyle(logging.PercentStyle):
     """Custom log formatter that add color to specific log levels."""
     grey: str = "38"
     yellow: str = "33"
     red: str = "31"
     cyan: str = "36"
+    green: str = "32"
 
     def _get_color_fmt(self, color_code, bold=False) -> str:
         if bold:
@@ -37,7 +55,8 @@ class ColorPercentStyle(logging.PercentStyle):
             logging.INFO: self._get_color_fmt(self.cyan),
             logging.WARNING: self._get_color_fmt(self.yellow),
             logging.ERROR: self._get_color_fmt(self.red),
-            logging.CRITICAL: self._get_color_fmt(self.red)
+            logging.CRITICAL: self._get_color_fmt(self.red),
+            logging.SUCCESS: self._get_color_fmt(self.green)
         }
 
         return colors.get(levelno, self._get_color_fmt(self.grey))

--- a/ci/logger.py
+++ b/ci/logger.py
@@ -66,8 +66,8 @@ class ColorPercentStyle(logging.PercentStyle):
 
 class CustomLogFormatter(logging.Formatter):
     """Formatter that removes creds from logs."""
-    ACCESS_KEY: str = os.environ.get("ACCESS_KEY","super_secret_key")
-    SECRET_KEY: str = os.environ.get("SECRET_KEY","super_secret_key")
+    ACCESS_KEY: str = os.environ.get("ACCESS_KEY","super_secret_key") or "super_secret_key" # If env is an empty string, use default value
+    SECRET_KEY: str = os.environ.get("SECRET_KEY","super_secret_key") or "super_secret_key" # If env is an empty string, use default value
 
     def formatException(self, exc_info) -> str:
         """Format an exception so that it prints on a single line."""

--- a/ci/template.html
+++ b/ci/template.html
@@ -563,7 +563,7 @@
             {% endif %}
             <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
           </div>
-          {% if screenshot == 'true' %}
+          {% if screenshot %}
           <a href="{{ tag }}.png">
             <img src="{{ tag }}.png" alt="{{ tag }}" width="600" height="auto" onerror="this.onerror=null; this.src='404.jpg'; this.parentElement.setAttribute('href','#')">
           </a>

--- a/ci/template.html
+++ b/ci/template.html
@@ -131,7 +131,8 @@
       .log-debug {color:lightgray}
       .log-info {color:lightskyblue}
       .log-warning {color:darkorange}
-      .log-error {color:red}
+      .log-error {color:red;font-weight: bolder;}
+      .log-success{color:limegreen;font-weight: bolder;}
     }
 
     @media (prefers-color-scheme: light) {
@@ -212,7 +213,8 @@
       .log-debug {color:#9bb0bf}
       .log-info {color:#60707c}
       .log-warning {color:darkorange}
-      .log-error {color:red}
+      .log-error {color:red;font-weight: bolder;}
+      .log-success{color:#009879;font-weight: bolder;}
     }
 
     body,
@@ -662,7 +664,8 @@
       pylogs = logs.replace(/\[38;20m/gi,"<span class='log-debug'>"
         ).replace(/\[33;20m/gi,"<span class='log-warning'>"
         ).replace(/\[31;20m/gi,"<span class='log-error'>"
-        ).replace(/\[36;20m/gi,"<span class='log-info'>"      
+        ).replace(/\[36;20m/gi,"<span class='log-info'>"
+        ).replace(/\[32;20m/gi,"<span class='log-success'>"
         ).replace(/\[0m/gi,"</span>")
         document.getElementById("logs").innerHTML = pylogs
     })

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,23 +38,25 @@ full_custom_readme: |
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /host/path:/ci/output:rw `#Optional, will contain all the files the container creates.` \
   -e IMAGE="linuxserver/<dockerimage>" \
-  -e TAGS="<single tag or array seperated by |>" \
+  -e TAGS="<single tag or array separated by |>" \
   -e META_TAG=<manifest main dockerhub tag> \
   -e BASE=<alpine or debian based distro> \
   -e SECRET_KEY=<S3 secret> \
   -e ACCESS_KEY=<S3 key> \
-  -e DOCKER_ENV="<optional, Array of env vars seperated by | IE test=test|test2=test2 or single var. Defaults to ''>" \
+  -e DOCKER_ENV="<optional, Array of env vars separated by | IE test=test|test2=test2 or single var. Defaults to ''>" \
   -e WEB_AUTH="<optional, format user:passord. Defaults to 'user:password'>" \
   -e WEB_PATH="<optional, format /yourpath>. Defaults to ''." \
   -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
   -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
-  -e WEB_SCREENSHOT_DELAY=<optional, time in seconds to delay before taking screenshot. Defaults to '30'>
+  -e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
+  -e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '5'> \
+  -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
   -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
-  -e DELAY_START=<optional, time in seconds to delay before taking screenshot. Defaults to '5'> \
   -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \
   -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
   -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'> \
-  -e DOCKER_LOGS_DELAY=<optional, How long to wait in seconds while tailing the container logs. Defaults to '300'> \
+  -e CI_LOG_LEVEL=<optional, Sets the ci logging level. Defaults to 'INFO'> \
+  -e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '900'> \
   -e DRY_RUN=<optional, Set to 'true' when you don't want to upload files to S3 when testing>
   -t lsiodev/ci:latest \
   python3 test_build.py

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,7 +49,7 @@ full_custom_readme: |
   -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
   -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
   -e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
-  -e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '5'> \
+  -e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
   -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
   -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
   -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,7 +49,7 @@ full_custom_readme: |
   -e S3_REGION=<optional, custom S3 Region. Defaults to 'us-east-1'> \
   -e S3_BUCKET=<optional, custom S3 Bucket. Defaults to 'ci-tests.linuxserver.io'> \
   -e WEB_SCREENSHOT_TIMEOUT=<optional, time in seconds before timing out trying to take a screenshot. Defaults to '120'>
-  -e SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
+  -e WEB_SCREENSHOT_DELAY=<optional, time in seconds to delay before taking a screenshot after loading the web page. Defaults to '10'> \
   -e SBOM_TIMEOUT=<optional, time in seconds before timing out trying to generate a SBOM. Defaults to '900'>
   -e WEB_SCREENSHOT=<optional, set to false if not a web app. Defaults to 'false'> \
   -e PORT=<optional, port web application listens on internal docker port. Defaults to '80'> \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -56,7 +56,7 @@ full_custom_readme: |
   -e SSL=<optional , use ssl for the screenshot true/false. Defaults to 'false'> \
   -e CI_S6_VERBOSITY=<optional, Updates the S6_VERBOSITY env. Defaults to '2'> \
   -e CI_LOG_LEVEL=<optional, Sets the ci logging level. Defaults to 'INFO'> \
-  -e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '900'> \
+  -e DOCKER_LOGS_TIMEOUT=<optional, How long to wait in seconds while tailing the container logs before timing out. Defaults to '120'> \
   -e DRY_RUN=<optional, Set to 'true' when you don't want to upload files to S3 when testing>
   -t lsiodev/ci:latest \
   python3 test_build.py


### PR DESCRIPTION
### Added

- Added dynamic timeout on the screenshot test. 

- New env variables:
  - `WEB_SCREENSHOT_TIMEOUT`: Replaces `WEB_SCREENSHOT_DELAY`. default 120s.
  - `WEB_SCREENSHOT_DELAY`: Time in seconds to delay before taking a screenshot after loading the web page. Default 10s
  - `DOCKER_LOGS_TIMEOUT`: Replaces `DOCKER_LOGS_DELAY`. default 120.
  
  - Added validation of the numeric class attributes. 
  - Added possibility to add volumes or privilege for future. Currently not in use.
  - Added new log level `success`. Logs with green text. 
    - ![image](https://github.com/linuxserver/docker-ci/assets/24592972/d1248f5a-be1b-4319-ad40-0bc402b3f7b3)

  - Added logging of env data

### Changed
 - Added helper method for adding test results.
 - Added how long a test takes in seconds.

### Deprecated

- DOCKER_LOGS_DELAY
- DELAY_START


### Tests

Lidarr: https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/lidarr/PR-70/index.html

Healthchecks: https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/healthchecks/PR-99/index.html

For local testing run:

```bash
docker run --rm -i \
-v /var/run/docker.sock:/var/run/docker.sock \
-v /mnt/c/development/docker-ci/output:/ci/output:rw \
-e META_TAG="PR-99" \
-e IMAGE="linuxserver/healthchecks" \
-e TAGS="amd64-v3.3-ls230|arm64v8-v3.3-ls230" \
-e BASE="alpine" \
-e S3_BUCKET="gilbnlsio2" \
-e S3_REGION="eu-north-1" \
-e SECRET_KEY="dummy" \
-e ACCESS_KEY="dummy" \
-e WEB_SCREENSHOT="true" \
-e WEB_SCREENSHOT_TIMEOUT="120" \
-e DOCKER_LOGS_TIMEOUT="120" \
-e SBOM_TIMEOUT="120" \
-e DELAY_START="20" \
-e PORT="8000" \
-e CI_LOG_LEVEL="INFO" \
-e DRY_RUN="true" \
-e DOCKER_ENV="TZ=US/Pacific|SITE_ROOT=http://*" \
-t dockerci:latest \
python3 test_build.py
```
```bash
docker run --rm -i \
-v /var/run/docker.sock:/var/run/docker.sock \
-v /mnt/c/development/docker-ci/output:/ci/output:rw \
-e META_TAG="PR-70" \
-e IMAGE="linuxserver/lidarr" \
-e TAGS="amd64-nightly-2.3.2.4178-ls131|arm64v8-nightly-2.3.2.4178-ls131" \
-e BASE="alpine" \
-e S3_BUCKET="gilbnlsio2" \
-e S3_REGION="eu-north-1" \
-e SECRET_KEY="dummy" \
-e ACCESS_KEY="dummy" \
-e WEB_SCREENSHOT="true" \
-e WEB_SCREENSHOT_TIMEOUT="120" \
-e WEB_AUTH="" \
-e DOCKER_LOGS_TIMEOUT="120" \
-e SBOM_TIMEOUT="120" \
-e PORT="8686" \
-e CI_LOG_LEVEL="INFO" \
-e DRY_RUN="true" \
-t dockerci:latest \
python3 test_build.py
```