### PR TITLE
43 feat run docker logs with t switch

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -288,14 +288,13 @@ class CI(SetEnvs):
 
 
         sbom: str = self.generate_sbom(tag)
-        logsfound: bool = self.watch_container_logs(container, tag) # Watch the logs for no more than 5 minutes
+        logsfound: bool = self.watch_container_logs(container, tag)
         if not logsfound:
             self.logger.error("Test of %s FAILED after %.2f seconds", tag, time.time() - start_time)
             build_info = {"version": "-", "created": "-", "size": "-", "maintainer": "-"}
             self._endtest(container, tag, build_info, sbom, False, start_time)
             return
 
-        # build_version: str = self.get_build_version(container,tag) # Get the image build version
         build_info: dict = self.get_build_info(container,tag) # Get the image build info
         if build_info["version"] == "ERROR":
             self.logger.error("Test of %s FAILED after %.2f seconds", tag, time.time() - start_time)

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -329,7 +329,7 @@ class CI(SetEnvs):
             runtime = "-"
         if isinstance(start_time,(float, int)):
             runtime = f"{time.time() - start_time:.2f}s"
-        logblob: Any = container.logs().decode("utf-8")
+        logblob: str = container.logs(timestamps=True).decode("utf-8")
         self.create_html_ansi_file(logblob, tag, "log") # Generate an html container log file based on the latest logs
         try:
             container.remove(force="true")


### PR DESCRIPTION
### Added

- Added timestamps to the container logs.

```
2024-06-11T09:05:29.733958650Z s6-rc: info: service s6rc-oneshot-runner: starting
2024-06-11T09:05:29.748101084Z s6-rc: info: service s6rc-oneshot-runner successfully started
2024-06-11T09:05:29.748675082Z s6-rc: info: service fix-attrs: starting
```

Test: https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/lidarr/PR-43/index.html