### PR TITLE
- Run generate_sbom and watch_container_logs concurrently so runtime …

### DIFF
--- a/ci/template.html
+++ b/ci/template.html
@@ -574,8 +574,13 @@
             {% else %}
             <h3 class="section-header-status"><span class="report-status-fail">FAIL</span></h3>
             {% endif %}
-            <h2 class="section-header-h2"> {{ image }}:{{ tag }} </h2>
-          </div>
+            <h2 class="section-header-h2">
+              {% if report_status.lower() == "pass" %}
+                <a target="_blank" href="https://ghcr.io/{{ image }}:{{ tag }}">{{ image }}:{{ tag }}</a>
+              {% else %}
+                {{ image }}:{{ tag }}
+              {% endif %}
+            </h2>          </div>
           <div class="runtime build-section">Runtime: {{ report_containers[tag]["runtime"] }}</div>
           {% if screenshot %}
           <a href="{{ tag }}.png">


### PR DESCRIPTION
## Added
- Adds a ghcr.io link for each tag. https://github.com/linuxserver/docker-ci/pull/45/files#diff-6e1065b4cd3882e2a20b10befa10f0332c1f27a429c2ccacb6f8abc77b4aba65R577-R583
  <img width="350" alt="image" src="https://github.com/linuxserver/docker-ci/assets/24592972/c0533f89-0a2a-4d8b-b90c-51e86d91ad7e">

- Run `generate_sbom` and `watch_container_logs` concurrently so runtime data is more correct. (Fixes watch_container_logs runtime = 0.1s etc, as init was already done while SBOM step was running) https://github.com/linuxserver/docker-ci/pull/45/files#diff-e97ac534a387e98dc58376ef7a27b87da2aacce4215acd88f634a5744a4c7859R291-R298
  ### Risks
  - Since the sbom test is not a "blocking" event anymore, there is a risk of the init failing if the passed or default `DOCKER_LOGS_TIMEOUT` value is too short. Previously the SBOM test had to complete or timeout before the init test was started. 

## Changed

- Always run get_build_info https://github.com/linuxserver/docker-ci/pull/45/files#diff-e97ac534a387e98dc58376ef7a27b87da2aacce4215acd88f634a5744a4c7859R298

## Fixed

- Use correct sbom data if build_info["version"] = ERROR https://github.com/linuxserver/docker-ci/pull/45/files#diff-e97ac534a387e98dc58376ef7a27b87da2aacce4215acd88f634a5744a4c7859R307
- Overwrite badge if it exists. https://github.com/linuxserver/docker-ci/pull/45/files#diff-e97ac534a387e98dc58376ef7a27b87da2aacce4215acd88f634a5744a4c7859R594


## Test: https://gilbnlsio2.s3.us-east-1.amazonaws.com/linuxserver/lidarr/concurrency-test/index.html
