### PR TITLE
add riscv64 support

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -396,6 +396,8 @@ class CI(SetEnvs):
                 return "arm64"
             case "arm32":
                 return "arm"
+            case "riscv":
+                return "riscv64"
             case _:
                 return "amd64"
 


### PR DESCRIPTION
Test build result:
https://ci-tests.linuxserver.io/lsiodev/jenkins-builder/957bc8d6-pkg-957bc8d6-dev-232c1f46162bfd38b47ed7bf5f6c8e40aa6b2208/index.html