### PR TITLE
add shm size to images we test as well

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -300,6 +300,7 @@ class CI(SetEnvs):
         # Start the container
         self.logger.info("Starting test of: %s", tag)
         container: Container = self.client.containers.run(f"{self.image}:{tag}",
+                                               shm_size="1G",
                                                detach=True,
                                                environment=self.dockerenv)
         container_config: list[str] = container.attrs["Config"]["Env"]


### PR DESCRIPTION
I have been getting inconsistent results with testing, this is a hard req on desktop container and has no negative impact on other containers which is why I did not parameterize it. 