### PR TITLE
Download the same chromedriver version as the installed chrome version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,13 @@ RUN \
     xserver-xephyr \
     xvfb && \
   echo "**** install chrome driver ****" && \
-  CHROME_RELEASE=$(curl -sLk https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE) && \
-  echo "Retrieving Chrome driver version ${CHROME_RELEASE}" && \
+  CHROME_VERSION=$(google-chrome --version | awk '{print $3}') && \
+  CHROME_MAJOR=${CHROME_VERSION%%.*} && \
+  CHROME_RELEASE=$(curl -fsSLk "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_MAJOR}" || true) && \
+  if [ -z "${CHROME_RELEASE}" ]; then \
+    CHROME_RELEASE=$(curl -fsSLk https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE); \
+  fi && \
+  echo "Installed Chrome ${CHROME_VERSION}; retrieving ChromeDriver ${CHROME_RELEASE}" && \
   curl -sk -o \
     /tmp/chrome.zip -L \
     "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_RELEASE}/linux64/chromedriver-linux64.zip" && \


### PR DESCRIPTION
<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/32831112-314c-4b54-9eae-05b2caa4159d" />

Test with:
```sh
docker run --rm -i \
 --shm-size=1gb \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v "$(pwd)/output:/ci/output" \
 -e CI_LOCAL_MODE=true \
 -e IMAGE="linuxserver/jackett" \
 -e TAGS="amd64-v0.24.993-ls296" \
 -e META_TAG="70-bug-wrong-chrome-driver-version" \
 -e BASE="alpine" \
 -e WEB_SCREENSHOT=true \
 -e PORT=9117 \
 -e SSL=false \
 -e WEB_PATH="" \
 -e WEB_AUTH="" \
 -e WEB_SCREENSHOT_TIMEOUT=60 \
 -e WEB_SCREENSHOT_DELAY=20 \
 -t ghcr.io/linuxserver/lspipepr-ci:54266ace-pkg-54266ace-dev-1b4d481b59054f3c420d984b7d3507c193056b6b-pr-71 \
 python3 test_build.py
```

---

```log
[36;20m01/02/2026 11:29:57 | MainThread        | root       | INFO     | (logger.configure_logging|line:127) | Operating system: Linux-6.17.9-arch1-1-x86_64-with-glibc2.39 |[0m
[36;20m01/02/2026 11:29:57 | MainThread        | root       | INFO     | (logger.configure_logging|line:128) | Python version: 3.12.3 |[0m
[33;20m01/02/2026 11:29:57 | MainThread        | SetEnvs    | WARNING  | (ci.__init__|line:141) | --- LOCAL MODE ACTIVE --- |[0m
[33;20m01/02/2026 11:29:57 | MainThread        | SetEnvs    | WARNING  | (ci.__init__|line:142) | S3 uploads will be skipped and dummy keys will be used. |[0m
[36;20m01/02/2026 11:29:57 | MainThread        | SetEnvs    | INFO     | (ci.__init__|line:187) | 
ENVIRONMENT DATA:
NODE_NAME:              'None'
IMAGE:                  'linuxserver/jackett'
BASE:                   'alpine'
META_TAG:               '70-bug-wrong-chrome-driver-version'
RELEASE_TAG:            'amd64-v0.24.993-ls296'
TAGS:                   'amd64-v0.24.993-ls296'
S6_VERBOSITY:           '2'
CI_S6_VERBOSITY         'None'
CI_LOG_LEVEL            'None'
DOCKER_ENV:             'None'
DOCKER_VOLUMES:         'None' (Not in use)
DOCKER_PRIVILEGED:      'None' (Not in use)
WEB_AUTH:               ''
WEB_PATH:               ''
WEB_SCREENSHOT:         'true'
WEB_SCREENSHOT_TIMEOUT: '60'
WEB_SCREENSHOT_DELAY:   '20'
DOCKER_LOGS_TIMEOUT:    'None'
SBOM_TIMEOUT:           'None'
DELAY_START:            'None' (Not in use)
PORT:                   '9117'
SSL:                    'false'
S3_REGION:              'None'
S3_BUCKET:              'None'
SYFT_IMAGE_TAG:         'None'
COMMIT_SHA:             'None'
BUILD_NUMBER:           'None'
BUILD_CACHE_REGISTRY:   'None'
Docker Engine Version:  '29.1.1'
 |[0m
[33;20m01/02/2026 11:29:57 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of create_s3_client |[0m
[36;20m01/02/2026 11:29:57 | AMD64Thread       | LSIO CI    | INFO     | (ci.container_test|line:357) | Starting test of: amd64-v0.24.993-ls296 |[0m
[36;20m01/02/2026 11:29:57 | AMD64Thread       | LSIO CI    | INFO     | (ci.container_test|line:363) | Container config of tag amd64-v0.24.993-ls296: ['PATH=/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'PS1=$(whoami)@$(hostname):$(pwd)\\$ ', 'HOME=/root', 'TERM=xterm', 'S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0', 'S6_VERBOSITY=1', 'S6_STAGE2_HOOK=/docker-mods', 'VIRTUAL_ENV=/lsiopy', 'LSIO_FIRST_PARTY=true', 'XDG_DATA_HOME=/config', 'XDG_CONFIG_HOME=/config', 'TMPDIR=/run/jackett-temp'] |[0m
[36;20m01/02/2026 11:29:57 | AMD64Thread_0     | LSIO CI    | INFO     | (ci.get_sbom_buildx_blob|line:690) | Generating SBOM for ghcr.io/linuxserver/lsiodev-buildcache:amd64-- using buildx imagetools inspect |[0m
[36;20m01/02/2026 11:29:57 | AMD64Thread_1     | LSIO CI    | INFO     | (ci.watch_container_logs|line:878) | Tailing the amd64-v0.24.993-ls296 logs for 120 seconds looking for the 'done' message |[0m
[31;20m01/02/2026 11:29:58 | AMD64Thread_0     | LSIO CI    | ERROR    | (ci.get_sbom_buildx_blob|line:696) | Failed to generate buildx SBOM for amd64-v0.24.993-ls296: ERROR: ghcr.io/linuxserver/lsiodev-buildcache:amd64--: not found
 |[0m
[33;20m01/02/2026 11:29:58 | AMD64Thread_0     | LSIO CI    | WARNING  | (ci.make_sbom|line:596) | Falling back to Syft for SBOM generation on tag amd64-v0.24.993-ls296 |[0m
[36;20m01/02/2026 11:29:58 | AMD64Thread_0     | LSIO CI    | INFO     | (ci.get_sbom_syft|line:621) | Creating SBOM package list on amd64-v0.24.993-ls296 with syft version v1.26.1 |[0m
[36;20m01/02/2026 11:29:58 | AMD64Thread_0     | LSIO CI    | INFO     | (ci.get_sbom_syft|line:624) | Tailing the Syft container logs for 900 seconds looking the 'VERSION' message on tag: amd64-v0.24.993-ls296 |[0m
[36;20m01/02/2026 11:30:03 | AMD64Thread_0     | LSIO CI    | INFO     | (ci.get_sbom_syft|line:630) | Get Syft package versions for amd64-v0.24.993-ls296 completed |[0m
[32;20m01/02/2026 11:30:03 | AMD64Thread_0     | LSIO CI    | SUCCESS  | (ci.get_sbom_syft|line:631) | Create Syft SBOM package list amd64-v0.24.993-ls296: PASSED after 5.17 seconds |[0m
[32;20m01/02/2026 11:30:03 | AMD64Thread_0     | LSIO CI    | SUCCESS  | (ci.make_sbom|line:602) | Create SBOM amd64-v0.24.993-ls296: PASSED after 5.96 seconds |[0m
[36;20m01/02/2026 11:30:03 | AMD64Thread_0     | LSIO CI    | INFO     | (ci.create_html_ansi_file|line:980) | Creating amd64-v0.24.993-ls296.sbom.html |[0m
[36;20m01/02/2026 11:30:03 | AMD64Thread_1     | LSIO CI    | INFO     | (ci.watch_container_logs|line:883) | Container Start completed for amd64-v0.24.993-ls296 |[0m
[32;20m01/02/2026 11:30:03 | AMD64Thread_1     | LSIO CI    | SUCCESS  | (ci.watch_container_logs|line:885) | Container Start amd64-v0.24.993-ls296: PASSED after 6.03 seconds |[0m
[36;20m01/02/2026 11:30:03 | AMD64Thread       | LSIO CI    | INFO     | (ci.get_build_info|line:844) | Fetching build info on tag: amd64-v0.24.993-ls296 |[0m
[32;20m01/02/2026 11:30:03 | AMD64Thread       | LSIO CI    | SUCCESS  | (ci.get_build_info|line:855) | Get build info on tag 'amd64-v0.24.993-ls296': PASS |[0m
[36;20m01/02/2026 11:30:03 | AMD64Thread       | LSIO CI    | INFO     | (ci.setup_driver|line:1179) | Init Chromedriver |[0m
[36;20m01/02/2026 11:30:04 | AMD64Thread       | LSIO CI    | INFO     | (ci.take_screenshot|line:1075) | Trying for 60 seconds to take a screenshot of amd64-v0.24.993-ls296  |[0m
[32;20m01/02/2026 11:30:25 | AMD64Thread       | LSIO CI    | SUCCESS  | (ci.take_screenshot|line:1087) | Screenshot amd64-v0.24.993-ls296: PASSED after 21.52 seconds |[0m
[36;20m01/02/2026 11:30:25 | AMD64Thread       | LSIO CI    | INFO     | (ci._get_browser_logs|line:457) | Getting browser console logs for tag amd64-v0.24.993-ls296 |[0m
[36;20m01/02/2026 11:30:25 | AMD64Thread       | LSIO CI    | INFO     | (ci.create_html_ansi_file|line:980) | Creating amd64-v0.24.993-ls296.browser.html |[0m
[36;20m01/02/2026 11:30:25 | AMD64Thread       | LSIO CI    | INFO     | (ci.create_html_ansi_file|line:980) | Creating amd64-v0.24.993-ls296.log.html |[0m
[32;20m01/02/2026 11:30:25 | AMD64Thread       | LSIO CI    | SUCCESS  | (ci.container_test|line:397) | Test of amd64-v0.24.993-ls296 PASSED after 27.96 seconds |[0m
[32;20m01/02/2026 11:30:25 | MainThread        | __main__   | SUCCESS  | (test_build.run_test|line:15) | All tests PASSED after 28.01 seconds |[0m
[36;20m01/02/2026 11:30:25 | MainThread        | LSIO CI    | INFO     | (ci.report_render|line:901) | Rendering Report |[0m
[36;20m01/02/2026 11:30:25 | MainThread        | LSIO CI    | INFO     | (ci.badge_render|line:920) | Creating badge |[0m
[36;20m01/02/2026 11:30:25 | MainThread        | LSIO CI    | INFO     | (ci.json_render|line:932) | Creating report.json file |[0m
[36;20m01/02/2026 11:30:25 | MainThread        | LSIO CI    | INFO     | (ci.report_upload|line:947) | Uploading report files |[0m
[33;20m01/02/2026 11:30:26 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:26 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:27 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:27 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:28 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:28 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:29 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:29 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:30 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:30 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:31 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[33;20m01/02/2026 11:30:31 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[36;20m01/02/2026 11:30:31 | MainThread        | LSIO CI    | INFO     | (ci.report_upload|line:965) | Report available on https://ci-tests.linuxserver.io/linuxserver/jackett/70-bug-wrong-chrome-driver-version/index.html |[0m
[36;20m01/02/2026 11:30:31 | MainThread        | LSIO CI    | INFO     | (ci.log_upload|line:1009) | Uploading logs |[0m
[33;20m01/02/2026 11:30:31 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
[36;20m01/02/2026 11:30:31 | MainThread        | LSIO CI    | INFO     | (ci.create_html_ansi_file|line:980) | Creating python.log.html |[0m
[33;20m01/02/2026 11:30:31 | MainThread        | ci.ci      | WARNING  | (ci.wrapper|line:48) | Dry run enabled, skipping execution of upload_file |[0m
```